### PR TITLE
Fixes the nested config override

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.7'
+
+services:
+  vault:
+    image: vault
+    ports:
+      # Opens tcp port 6379 on the host and service container
+      - 8200:8200
+    environment:
+      - VAULT_DISABLE_MLOCK=True
+      - VAULT_ADDR=http://localhost:8200
+      - VAULT_DEV_ROOT_TOKEN_ID=myroot

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   vault:
     image: vault
     ports:
-      # Opens tcp port 6379 on the host and service container
+      # Opens tcp port 8200 on the host and service container
       - 8200:8200
     environment:
       - VAULT_DISABLE_MLOCK=True

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Will be rendered to this in the internal data structure:
 
 The nested values are flattened and delimited by periods, making access simpler. **Note**, Gestalt will not normalize names in config files, so keys are case sensitive.
 
+The behaviour of nested dictionary overrides, on key collision, is it updates the dict with non existent keys and overrides the collision keys in the nested dictionary.
+
 ### Environment Variables
 
 Environment variable overrides are not enabled by default. To enable it:

--- a/README.md
+++ b/README.md
@@ -129,7 +129,37 @@ Will be rendered to this in the internal data structure:
 
 The nested values are flattened and delimited by periods, making access simpler. **Note**, Gestalt will not normalize names in config files, so keys are case sensitive.
 
-The behaviour of nested dictionary overrides, on key collision, is it updates the dict with non existent keys and overrides the collision keys in the nested dictionary.
+Nested dictionaries are merged recursively. For example:
+
+```py
+# config1.json file contents.
+{
+  "db": {
+    "name": "fake"
+  },
+  "replicas": 1,
+}
+
+# config2.json file contents.
+{
+  "db": {
+    "name": "mydb",
+    "password": "password"
+  },
+}
+
+g.add_config_file('./config1.json')
+g.add_config_file('./config2.json')
+
+# Merged result.
+{
+  "db": {
+    "name": "mydb",
+    "password": "password"
+  },
+  "replicas": 1,
+}
+```
 
 ### Environment Variables
 

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -136,7 +136,8 @@ class Gestalt:
                 try:
                     with open(f) as jf:
                         json_dict = json.load(jf)
-                        self.__conf_data.update(json_dict)
+                        json_dict_flatten = self.__flatten(json_dict)
+                        self.__conf_data.update(json_dict_flatten)
                 except json.JSONDecodeError as e:
                     raise ValueError(
                         f'File {f} is marked as ".json" but cannot be read as such: {e}'
@@ -145,14 +146,20 @@ class Gestalt:
                 try:
                     with open(f) as yf:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        self.__conf_data.update(yaml_dict)
+                        print("Yaml:", yaml_dict)
+                        yaml_dict_flatten = self.__flatten(yaml_dict, self.__delim_char)
+                        self.__conf_data.update(yaml_dict_flatten)
                 except yaml.YAMLError as e:
                     raise ValueError(
                         f'File {f} is marked as ".yaml" but cannot be read as such: {e}'
                     )
 
+        print("from gestalt:", self.__conf_data)
+
         self.__conf_data = self.__flatten(self.__conf_data,
                                           sep=self.__delim_char)
+
+        print("after flattening:", self.__conf_data)
 
         self.__parse_dictionary_keys(self.__conf_data)
         self.__conf_data = self.__interpolate_keys(self.__conf_data)

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -115,7 +115,7 @@ class Gestalt:
                 with open(json_file) as jf:
                     try:
                         json_dict = json.load(jf)
-                        self.__combine_into(json_dict, self.__conf_data)
+                        self.combine_into(json_dict, self.__conf_data)
                     except json.JSONDecodeError as e:
                         raise ValueError(
                             f'File {json_file} is marked as ".json" but cannot be read as such: {e}'
@@ -124,7 +124,7 @@ class Gestalt:
                 with open(yaml_file) as yf:
                     try:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        self.__combine_into(yaml_dict, self.__conf_data)
+                        self.combine_into(yaml_dict, self.__conf_data)
                     except yaml.YAMLError as e:
                         raise ValueError(
                             f'File {yaml_file} is marked as ".yaml" but cannot be read as such: {e}'
@@ -136,7 +136,7 @@ class Gestalt:
                 try:
                     with open(f) as jf:
                         json_dict = json.load(jf)
-                        self.__combine_into(json_dict, self.__conf_data)
+                        self.combine_into(json_dict, self.__conf_data)
                 except json.JSONDecodeError as e:
                     raise ValueError(
                         f'File {f} is marked as ".json" but cannot be read as such: {e}'
@@ -145,7 +145,7 @@ class Gestalt:
                 try:
                     with open(f) as yf:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        self.__combine_into(yaml_dict, self.__conf_data)
+                        self.combine_into(yaml_dict, self.__conf_data)
                 except yaml.YAMLError as e:
                     raise ValueError(
                         f'File {f} is marked as ".yaml" but cannot be read as such: {e}'
@@ -159,13 +159,13 @@ class Gestalt:
         self.__parse_dictionary_keys(self.__conf_sets)
         self.__conf_sets = self.__interpolate_keys(self.__conf_sets)
 
-    def __combine_into(
+    def combine_into(
         self, d: Dict[Text, Union[List[Any], Text, int, bool, float]],
         combined: Dict[Text, Union[List[Any], Text, int, bool, float]]
     ) -> None:
         for k, v in d.items():
             if isinstance(v, dict):
-                self.__combine_into(v, combined.setdefault(k, {}))
+                self.combine_into(v, combined.setdefault(k, {}))
             else:
                 combined[k] = v
 

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -115,7 +115,8 @@ class Gestalt:
                 with open(json_file) as jf:
                     try:
                         json_dict = json.load(jf)
-                        self.__conf_data.update(json_dict)
+                        json_dict_flatten = self.__flatten(json_dict)
+                        self.__conf_data.update(json_dict_flatten)
                     except json.JSONDecodeError as e:
                         raise ValueError(
                             f'File {json_file} is marked as ".json" but cannot be read as such: {e}'
@@ -124,7 +125,8 @@ class Gestalt:
                 with open(yaml_file) as yf:
                     try:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        self.__conf_data.update(yaml_dict)
+                        yaml_dict_flatten = self.__flatten(yaml_dict)
+                        self.__conf_data.update(yaml_dict_flatten)
                     except yaml.YAMLError as e:
                         raise ValueError(
                             f'File {yaml_file} is marked as ".yaml" but cannot be read as such: {e}'
@@ -146,20 +148,15 @@ class Gestalt:
                 try:
                     with open(f) as yf:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        print("Yaml:", yaml_dict)
-                        yaml_dict_flatten = self.__flatten(yaml_dict, self.__delim_char)
+                        yaml_dict_flatten = self.__flatten(yaml_dict)
                         self.__conf_data.update(yaml_dict_flatten)
                 except yaml.YAMLError as e:
                     raise ValueError(
                         f'File {f} is marked as ".yaml" but cannot be read as such: {e}'
                     )
 
-        print("from gestalt:", self.__conf_data)
-
         self.__conf_data = self.__flatten(self.__conf_data,
                                           sep=self.__delim_char)
-
-        print("after flattening:", self.__conf_data)
 
         self.__parse_dictionary_keys(self.__conf_data)
         self.__conf_data = self.__interpolate_keys(self.__conf_data)

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -159,7 +159,10 @@ class Gestalt:
         self.__parse_dictionary_keys(self.__conf_sets)
         self.__conf_sets = self.__interpolate_keys(self.__conf_sets)
 
-    def __combine_into(self, d: dict, combined: dict) -> None:
+    def __combine_into(
+        self, d: Dict[Text, Union[List[Any], Text, int, bool, float]],
+        combined: Dict[Text, Union[List[Any], Text, int, bool, float]]
+    ) -> None:
         for k, v in d.items():
             if isinstance(v, dict):
                 self.__combine_into(v, combined.setdefault(k, {}))

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -9,6 +9,17 @@ from typing import Dict, List, Type, Union, Optional, MutableMapping, Text, Any
 import yaml
 
 
+def merge_into(
+        a: Dict[Text, Union[List[Any], Text, int, bool, float]],
+        b: Dict[Text, Union[List[Any], Text, int, bool, float]]) -> None:
+    """ merge_into merges a into b"""
+    for k, v in a.items():
+        if isinstance(v, dict):
+            merge_into(v, b.setdefault(k, {}))
+        else:
+            b[k] = v
+
+
 class Gestalt:
     def __init__(self) -> None:
         """ Creates the default configuration manager
@@ -115,7 +126,7 @@ class Gestalt:
                 with open(json_file) as jf:
                     try:
                         json_dict = json.load(jf)
-                        self.combine_into(json_dict, self.__conf_data)
+                        merge_into(json_dict, self.__conf_data)
                     except json.JSONDecodeError as e:
                         raise ValueError(
                             f'File {json_file} is marked as ".json" but cannot be read as such: {e}'
@@ -124,7 +135,7 @@ class Gestalt:
                 with open(yaml_file) as yf:
                     try:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        self.combine_into(yaml_dict, self.__conf_data)
+                        merge_into(yaml_dict, self.__conf_data)
                     except yaml.YAMLError as e:
                         raise ValueError(
                             f'File {yaml_file} is marked as ".yaml" but cannot be read as such: {e}'
@@ -136,7 +147,7 @@ class Gestalt:
                 try:
                     with open(f) as jf:
                         json_dict = json.load(jf)
-                        self.combine_into(json_dict, self.__conf_data)
+                        merge_into(json_dict, self.__conf_data)
                 except json.JSONDecodeError as e:
                     raise ValueError(
                         f'File {f} is marked as ".json" but cannot be read as such: {e}'
@@ -145,7 +156,7 @@ class Gestalt:
                 try:
                     with open(f) as yf:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        self.combine_into(yaml_dict, self.__conf_data)
+                        merge_into(yaml_dict, self.__conf_data)
                 except yaml.YAMLError as e:
                     raise ValueError(
                         f'File {f} is marked as ".yaml" but cannot be read as such: {e}'
@@ -158,16 +169,6 @@ class Gestalt:
         self.__conf_data = self.__interpolate_keys(self.__conf_data)
         self.__parse_dictionary_keys(self.__conf_sets)
         self.__conf_sets = self.__interpolate_keys(self.__conf_sets)
-
-    def combine_into(
-        self, d: Dict[Text, Union[List[Any], Text, int, bool, float]],
-        combined: Dict[Text, Union[List[Any], Text, int, bool, float]]
-    ) -> None:
-        for k, v in d.items():
-            if isinstance(v, dict):
-                self.combine_into(v, combined.setdefault(k, {}))
-            else:
-                combined[k] = v
 
     def __parse_dictionary_keys(
         self, dictionary: Dict[str, Union[List[Any], str, int, bool, float]]

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -115,8 +115,7 @@ class Gestalt:
                 with open(json_file) as jf:
                     try:
                         json_dict = json.load(jf)
-                        json_dict_flatten = self.__flatten(json_dict)
-                        self.__conf_data.update(json_dict_flatten)
+                        self.__combine_into(json_dict, self.__conf_data)
                     except json.JSONDecodeError as e:
                         raise ValueError(
                             f'File {json_file} is marked as ".json" but cannot be read as such: {e}'
@@ -125,8 +124,7 @@ class Gestalt:
                 with open(yaml_file) as yf:
                     try:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        yaml_dict_flatten = self.__flatten(yaml_dict)
-                        self.__conf_data.update(yaml_dict_flatten)
+                        self.__combine_into(yaml_dict, self.__conf_data)
                     except yaml.YAMLError as e:
                         raise ValueError(
                             f'File {yaml_file} is marked as ".yaml" but cannot be read as such: {e}'
@@ -138,8 +136,7 @@ class Gestalt:
                 try:
                     with open(f) as jf:
                         json_dict = json.load(jf)
-                        json_dict_flatten = self.__flatten(json_dict)
-                        self.__conf_data.update(json_dict_flatten)
+                        self.__combine_into(json_dict, self.__conf_data)
                 except json.JSONDecodeError as e:
                     raise ValueError(
                         f'File {f} is marked as ".json" but cannot be read as such: {e}'
@@ -148,8 +145,7 @@ class Gestalt:
                 try:
                     with open(f) as yf:
                         yaml_dict = yaml.load(yf, Loader=yaml.FullLoader)
-                        yaml_dict_flatten = self.__flatten(yaml_dict)
-                        self.__conf_data.update(yaml_dict_flatten)
+                        self.__combine_into(yaml_dict, self.__conf_data)
                 except yaml.YAMLError as e:
                     raise ValueError(
                         f'File {f} is marked as ".yaml" but cannot be read as such: {e}'
@@ -162,6 +158,13 @@ class Gestalt:
         self.__conf_data = self.__interpolate_keys(self.__conf_data)
         self.__parse_dictionary_keys(self.__conf_sets)
         self.__conf_sets = self.__interpolate_keys(self.__conf_sets)
+
+    def __combine_into(self, d: dict, combined: dict) -> None:
+        for k, v in d.items():
+            if isinstance(v, dict):
+                self.__combine_into(v, combined.setdefault(k, {}))
+            else:
+                combined[k] = v
 
     def __parse_dictionary_keys(
         self, dictionary: Dict[str, Union[List[Any], str, int, bool, float]]

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -5,7 +5,7 @@ mypy-extensions==0.4.3
 pytest==4.3.1
 pytest-cov==2.8.1
 codecov==2.0.15
-hvac==0.10.9
+hvac==0.11.2
 types-requests==2.25.2
 types-PyYAML==5.4.3
 jsonpath-ng==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML==5.4.1
-hvac==0.10.9
+hvac==0.11.2
 jsonpath-ng==1.5.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='gestalt-cfg',
-      version='2.0.3',
+      version='3.0.0',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -1,6 +1,7 @@
 # type: ignore
 
 from gestalt.vault import Vault
+from gestalt import merge_into
 import pytest
 import os
 import gestalt
@@ -8,31 +9,19 @@ import hvac
 
 
 # Testing member function
-def test_combined_into():
-    g = gestalt.Gestalt()
-    dictionary = {}
-    dictionary_ = {} 
-    dict1 = {
-        "local": 1234,
-        "pg": {
-            "host": "dict1_pg",
-            "pass": "dict1_pg"
-        }
-    }
-    dict2 = {
-        "local": 1234,
-        "pg": {
-            "host": "dict2_pg"
-        }
-    }
+def test_merge_into():
+    combine1 = {}
+    combine2 = {}
+    combine3 = {"local": 1234, "pg": {"host": "dict1_pg", "pass": "dict1_pg"}}
+    combine4 = {"local": 1234, "pg": {"host": "dict2_pg"}}
 
-    g.combine_into(dict1, dictionary)
-    g.combine_into(dict2, dictionary)
+    merge_into(combine3, combine1)
+    merge_into(combine4, combine1)
 
-    g.combine_into(dict2, dictionary_)
-    g.combine_into(dict1, dictionary_)
+    merge_into(combine4, combine2)
+    merge_into(combine3, combine2)
 
-    assert dictionary == {
+    assert combine1 == {
         "local": 1234,
         "pg": {
             "host": "dict2_pg",
@@ -40,7 +29,7 @@ def test_combined_into():
         }
     }
 
-    assert dictionary_ == {
+    assert combine2 == {
         "local": 1234,
         "pg": {
             "host": "dict1_pg",
@@ -48,6 +37,15 @@ def test_combined_into():
         }
     }
 
+
+def test_combine_into_empty_dict():
+    combine = {}
+    merge_into({}, combine)
+    assert combine == {}
+
+    combine = {"local": 1234}
+    merge_into({}, combine)
+    assert combine == {"local": 1234}
 
 
 # Testing JSON Loading

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -414,6 +414,7 @@ def test_override_nested_config():
     assert g.get_string("nested1.nested2") == "final"
     assert g.get_string("pg.host") == "dev_host"
     assert g.get_string("pg.pass") == "def_pass"
+    assert g.get_string("nested1.nested3.nested4.deeplevel") == "nested5"
 
 
 def test_set_default_bad_type_file_config():

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -7,6 +7,49 @@ import gestalt
 import hvac
 
 
+# Testing member function
+def test_combined_into():
+    g = gestalt.Gestalt()
+    dictionary = {}
+    dictionary_ = {} 
+    dict1 = {
+        "local": 1234,
+        "pg": {
+            "host": "dict1_pg",
+            "pass": "dict1_pg"
+        }
+    }
+    dict2 = {
+        "local": 1234,
+        "pg": {
+            "host": "dict2_pg"
+        }
+    }
+
+    g.combine_into(dict1, dictionary)
+    g.combine_into(dict2, dictionary)
+
+    g.combine_into(dict2, dictionary_)
+    g.combine_into(dict1, dictionary_)
+
+    assert dictionary == {
+        "local": 1234,
+        "pg": {
+            "host": "dict2_pg",
+            "pass": "dict1_pg"
+        }
+    }
+
+    assert dictionary_ == {
+        "local": 1234,
+        "pg": {
+            "host": "dict1_pg",
+            "pass": "dict1_pg"
+        }
+    }
+
+
+
 # Testing JSON Loading
 def test_loading_json():
     g = gestalt.Gestalt()

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -406,6 +406,16 @@ def test_set_default_string_bad_val_override():
         assert 'Overriding default key' in terr
 
 
+def test_override_nested_config():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testoverride/')
+    g.build_config()
+    assert g.get_int("local") == 123456
+    assert g.get_string("nested1.nested2") == "final"
+    assert g.get_string("pg.host") == "dev_host"
+    assert g.get_string("pg.pass") == "def_pass"
+
+
 def test_set_default_bad_type_file_config():
     g = gestalt.Gestalt()
     g.add_config_path('./tests/testdata')
@@ -438,7 +448,6 @@ def test_vault_setup(env_setup):
 @pytest.fixture(scope="function")
 def incorrect_env_setup():
     os.environ['VAULT_ADDR'] = ""
-    os.environ['VAULT_ADDR'] = ""
 
 
 @pytest.fixture(scope="function")
@@ -454,7 +463,6 @@ def test_vault_interpolation(secret_setup):
     vault = Vault(role=None, jwt=None)
     g.configure_provider("vault", vault)
     g.build_config()
-    print(g.dump())
     secret = g.get_string("test_secret.test_secret")
     assert secret == "test_secret_password"
 
@@ -478,9 +486,7 @@ def test_vault_mount_path(env_setup, mount_setup):
     g.add_config_file("./tests/testvault/testmount.json")
     g.configure_provider("vault", Vault(role=None, jwt=None))
     g.build_config()
-    print("config:", g.dump())
     secret = g.get_string("test_mount.test_mount")
-    print("secret:", secret)
     assert secret == "test_mount_password"
 
 
@@ -504,11 +510,8 @@ def test_nest_key_for_vault(env_setup, nested_setup):
     g.add_config_file("./tests/testvault/testnested.json")
     g.configure_provider("vault", Vault(role=None, jwt=None))
     g.build_config()
-    print("config:", g.dump())
     secret_db = g.get_string("remoteAPI.database.test_secret")
     secret_slack = g.get_string("remoteAPI.slack.token")
-    print("secret_db:", secret_db)
-    print("secret_slack:", secret_slack)
     assert secret_db == "test_secret_password"
     assert secret_slack == "random-token"
 
@@ -519,6 +522,5 @@ def test_set_vault_key(env_setup, nested_setup):
     g.set_string(key="test",
                  value="ref+vault://secret/data/testnested#.slack.token")
     g.build_config()
-    print("config:", g.dump())
     secret = g.get_string("test")
     assert secret == "random-token"

--- a/tests/testoverride/testdefault.json
+++ b/tests/testoverride/testdefault.json
@@ -1,0 +1,6 @@
+{
+    "local": "124",
+    "nested1": {
+        "nested2": "hello"
+    }
+}

--- a/tests/testoverride/testdefault.yaml
+++ b/tests/testoverride/testdefault.yaml
@@ -1,0 +1,8 @@
+local: 123
+
+nested1:
+  nested2: final
+
+pg:
+  host: def_host
+  pass: def_pass

--- a/tests/testoverride/testdefault2.yaml
+++ b/tests/testoverride/testdefault2.yaml
@@ -1,0 +1,4 @@
+local: 123456
+
+pg:
+  host: dev_host

--- a/tests/testoverride/testdefault3.yaml
+++ b/tests/testoverride/testdefault3.yaml
@@ -1,0 +1,4 @@
+nested1:
+  nested3:
+    nested4:
+      deeplevel: "nested5"


### PR DESCRIPTION
## Issue Summary
Gestalt was incorrectly handling the override of the nested config overrides. The reason behind this was using python update function for a dictionary actually on a key collision does not do a nested update but rather takes the newer dictionary.\

Example:
```py
dict1 = {
  "local": 1234,
  "pg": {
    "host": "dict1_host",
    "pass": "dict1_pass"
  }
}

dict2 = {
  "local": 12345678,
  "pg": {
    "host": "dict2_host",
  }
}

# Test 1
dict = {}
dict.update(dict1)
dict.update(dict2)
print(dict)

# Test 2
dict = {}
dict.update(dict2)
dict.update(dict1)
print(dict)
```

The result of Test 1 is `{'local': 12345678, 'pg': {'host': 'dict2_host'}}` but if the order switches which is the case in Test 2 the result becomes `{'local': 1234, 'pg': {'host': 'dict1_host', 'pass': 'dict1_pass'}}`

Hence there is a loss in overriding the nested values

## Solution
The solution implemented is using a combined function that merges the dictionaries based on their key and on collision, it will check the subsequent values in the nested dictionary and update by adding the non-existent keys and overwriting any keys with a collision on the leaf level or were added later.