### PR TITLE
Update TTL Renew Threads to be Daemon Threads

### DIFF
--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -62,10 +62,12 @@ class Vault(Provider):
 
             dynamic_ttl_renew = Thread(name='dynamic-token-renew',
                                        target=asyncio.run,
+                                       daemon=True,
                                        args=(self.worker(
                                            self.dynamic_token_queue), ))
             kubernetes_ttl_renew = Thread(name="kubes-token-renew",
                                           target=asyncio.run,
+                                          daemon=True,
                                           args=(self.worker(
                                               self.kubes_token_queue), ))
             kubernetes_ttl_renew.start()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.1.0',
+      version='3.1.1',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
- The worker threads were non-daemon threads that would continue to live on after the main thread exited.
- The above change converts them to daemon threads which would mean that the sub-threads would exit when the main thread exits