### PR TITLE
Add support for not nested data in response

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -60,7 +60,6 @@ jobs:
         VAULT_TOKEN: "myroot"
       run: |
         pytest -s --cov=gestalt tests/*.py
-        codecov
     - name: Typecheck with mypy
       run: |
         # run mypy strict mode on gestalt

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -90,7 +90,7 @@ class Vault(Provider):
                 dynamic_token = ("dynamic", response['lease_id'],
                                  response['lease_duration'])
                 self.dynamic_token_queue.put_nowait(dynamic_token)
-            requested_data = response["data"]["data"]
+            requested_data = response["data"].get("data", response["data"])
         except hvac.exceptions.InvalidPath:
             raise RuntimeError(
                 "Gestalt Error: The secret path or mount is set incorrectly")

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -4,6 +4,7 @@ mypy==0.910
 mypy-extensions==0.4.3
 pytest==6.1.0
 pytest-cov==2.8.1
+pytest-mock==3.10.0
 codecov==2.0.16
 hvac>=1.0.2,<1.1.0
 types-requests==2.25.2

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -4,7 +4,7 @@ mypy==0.910
 mypy-extensions==0.4.3
 pytest==6.1.0
 pytest-cov==2.8.1
-codecov==2.0.16
+pytest-mock==3.2.0
 hvac>=1.0.2,<1.1.0
 types-requests==2.25.2
 types-PyYAML==5.4.6

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -4,7 +4,7 @@ mypy==0.910
 mypy-extensions==0.4.3
 pytest==6.1.0
 pytest-cov==2.8.1
-pytest-mock==3.10.0
+pytest-mock==3.2.0
 codecov==2.0.16
 hvac>=1.0.2,<1.1.0
 types-requests==2.25.2

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -4,7 +4,6 @@ mypy==0.910
 mypy-extensions==0.4.3
 pytest==6.1.0
 pytest-cov==2.8.1
-pytest-mock==3.2.0
 codecov==2.0.16
 hvac>=1.0.2,<1.1.0
 types-requests==2.25.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.1.2',
+      version='3.2.0',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.1.1',
+      version='3.1.2',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -14,7 +14,22 @@ import requests
 
 class MockSession(requests.Session):
     def request(self, *_, **__):
-        resp = {'request_id': '230f5e67-e55d-bdae-bd24-c7bc13c1a3e9', 'lease_id': '', 'renewable': False, 'lease_duration': 0, 'data': {'last_vault_rotation': '2023-05-31T14:24:41.724285249Z', 'password': 'foo', 'rotation_period': 60, 'ttl': 0, 'username': 'foo'}, 'wrap_info': None, 'warnings': None, 'auth': None}
+        resp = {
+            'request_id': '230f5e67-e55d-bdae-bd24-c7bc13c1a3e9',
+            'lease_id': '',
+            'renewable': False,
+            'lease_duration': 0,
+            'data': {
+                'last_vault_rotation': '2023-05-31T14:24:41.724285249Z',
+                'password': 'foo',
+                'rotation_period': 60,
+                'ttl': 0,
+                'username': 'foo'
+            },
+            'wrap_info': None,
+            'warnings': None,
+            'auth': None
+        }
         return MockResponse(resp, 200)
 
 
@@ -584,7 +599,6 @@ def nested_setup(env_setup):
     client = hvac.Client()
     client.secrets.kv.v2.create_or_update_secret(
         path="testnested", secret=dict(slack={"token": "random-token"}))
-
 
 
 def test_nest_key_for_vault(env_setup, nested_setup):

--- a/tests/testvault/testsfdynamic.json
+++ b/tests/testvault/testsfdynamic.json
@@ -1,0 +1,3 @@
+{
+    "snowflake": "ref+vault://database/creds/my-role#"
+}


### PR DESCRIPTION
* adds support for not nested data in response
* the `coverage` package has been removed from pypi https://github.com/home-assistant/core/issues/91283. Removes `coverage` dependency (`gestalt` uses pytest-cov during tests as is)