### PR TITLE
Add ttl and caching support in vault provider

### DIFF
--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -149,8 +149,7 @@ class Gestalt:
                         f'File {f} is marked as ".yaml" but cannot be read as such: {e}'
                     )
 
-        self.__conf_data = flatten(self.__conf_data,
-                                          sep=self.__delim_char)
+        self.__conf_data = flatten(self.__conf_data, sep=self.__delim_char)
 
         self.__parse_dictionary_keys(self.__conf_data)
         self.__parse_dictionary_keys(self.__conf_sets)
@@ -392,14 +391,17 @@ class Gestalt:
             raise TypeError(f'Given key is not of string type')
         if default and not isinstance(default, t):
             raise TypeError(
-            f'Provided default is of incorrect type {type(default)}, it should be of type {t}'
+                f'Provided default is of incorrect type {type(default)}, it should be of type {t}'
             )
         split_keys = key.split(self.__delim_char)
         consider_keys = list()
         for split_key in split_keys:
             consider_keys.append(split_key)
             joined_key = ".".join(consider_keys)
-            config_val = self._get_config_for_key(key=key, key_to_search=joined_key, default=default, object_type=t)
+            config_val = self._get_config_for_key(key=key,
+                                                  key_to_search=joined_key,
+                                                  default=default,
+                                                  object_type=t)
             if config_val is not None:
                 return config_val
 
@@ -543,11 +545,11 @@ class Gestalt:
         ret.update(self.__conf_sets)
         return str(json.dumps(ret, indent=4))
 
-    def _get_config_for_key(self,
-                            key: str,
-                            key_to_search: str,
-                            default: Optional[Union[str, int, float, bool,List[Any]]],
-                            object_type: Type[Union[str, int, float, bool, List[Any]]]) -> Optional[Union[str, int, float, bool, List[Any]]]:
+    def _get_config_for_key(
+        self, key: str, key_to_search: str,
+        default: Optional[Union[str, int, float, bool, List[Any]]],
+        object_type: Type[Union[str, int, float, bool, List[Any]]]
+    ) -> Optional[Union[str, int, float, bool, List[Any]]]:
         if key_to_search in self.__conf_sets:
             val = self.__conf_sets[key_to_search]
             if not isinstance(val, object_type):

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -545,7 +545,7 @@ class Gestalt:
 
     def _get_config_for_key(self,
                             key: str,
-                            key_to_search,
+                            key_to_search: str,
                             default: Optional[Union[str, int, float, bool,List[Any]]],
                             object_type: Type[Union[str, int, float, bool, List[Any]]]) -> Optional[Union[str, int, float, bool, List[Any]]]:
         if key_to_search in self.__conf_sets:
@@ -568,7 +568,7 @@ class Gestalt:
         if key_to_search in self.__conf_data:
             val = self.__conf_data[key_to_search]
             for provider in self.providers.values():
-                if val.startswith(provider.scheme):
+                if isinstance(val, str) and val.startswith(provider.scheme):
                     regex_search = self.regex_pattern.search(val)
                     if regex_search is not None:
                         path = regex_search.group(2)
@@ -602,3 +602,4 @@ class Gestalt:
                     f'Given default set key is not of type {object_type}, but of type {type(val)}'
                 )
             return val
+        return

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -1,4 +1,4 @@
-from gestalt.vault import Vault
+from gestalt.vault import Vault  # noqa: E999
 from gestalt.provider import Provider
 import os
 import glob

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -153,9 +153,7 @@ class Gestalt:
                                           sep=self.__delim_char)
 
         self.__parse_dictionary_keys(self.__conf_data)
-        # self.__conf_data = self.__interpolate_keys(self.__conf_data)
         self.__parse_dictionary_keys(self.__conf_sets)
-        # self.__conf_sets = self.__interpolate_keys(self.__conf_sets)
 
     def __parse_dictionary_keys(
         self, dictionary: Dict[str, Union[List[Any], str, int, bool, float]]
@@ -194,24 +192,6 @@ class Gestalt:
             self.providers.update({"vault": provider})
         else:
             raise TypeError("Provider provider is not supported")
-
-    def __interpolate_keys(
-        self, dictionary: Dict[str, Union[List[Any], str, int, bool, float]]
-    ) -> Dict[str, Union[List[Any], str, int, bool, float]]:
-        """Interpolates the keys in the configuration data.
-        """
-        for path, v in self.__secret_map.items():
-            m = self.regex_pattern.search(path)
-            if m is not None:
-                provider = self.providers[m.group(1)]
-                for config_key in v:
-                    secret = provider.get(key=config_key,
-                                          path=m.group(2),
-                                          filter=m.group(3))
-                    dictionary.update({config_key: secret})
-
-        dictionary = flatten(dictionary, sep=self.__delim_char)
-        return dictionary
 
     def auto_env(self) -> None:
         """Auto env provides sane defaults for using environment variables

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -602,4 +602,4 @@ class Gestalt:
                     f'Given default set key is not of type {object_type}, but of type {type(val)}'
                 )
             return val
-        return
+        return None

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -416,8 +416,6 @@ class Gestalt:
             )
         split_keys = key.split(self.__delim_char)
         consider_keys = list()
-        print(f"CONF DATA {self.__conf_data}")
-        print(f"CONF SETS {self.__conf_sets}")
         for split_key in split_keys:
             consider_keys.append(split_key)
             joined_key = ".".join(consider_keys)
@@ -588,26 +586,21 @@ class Gestalt:
                     )
 
         if key_to_search in self.__conf_data:
-            print(f"KEY {key_to_search} IN CONF DATA")
             val = self.__conf_data[key_to_search]
-            print(f"THE VAL {val}")
             for provider in self.providers.values():
                 if val.startswith(provider.scheme):
                     regex_search = self.regex_pattern.search(val)
                     if regex_search is not None:
                         path = regex_search.group(2)
                         filter_ = regex_search.group(3)
-                        print(f"ORIGINAL KEY {key} cur key {key_to_search}")
                         remainder_filter = key[len(key_to_search):]
                         if len(remainder_filter) > 1:
-                            print("IN REMAINDER KEYS")
                             if filter_ is not None:
                                 filter_ = f".{filter_}{remainder_filter}"
 
                             else:
                                 filter_ = remainder_filter
 
-                        print(f"filter is {filter_}")
                         interpolated_val = provider.get(key=val,
                                                         path=path,
                                                         filter=filter_,
@@ -615,7 +608,6 @@ class Gestalt:
                         break
             else:
                 interpolated_val = val
-            print(f"{interpolated_val=}")
             if not isinstance(interpolated_val, object_type):
                 raise TypeError(
                     f'Given set key is not of type {object_type}, but of type {type(interpolated_val)}'

--- a/gestalt/__init__.py
+++ b/gestalt/__init__.py
@@ -397,7 +397,7 @@ class Gestalt:
         consider_keys = list()
         for split_key in split_keys:
             consider_keys.append(split_key)
-            joined_key = ".".join(consider_keys)
+            joined_key = self.__delim_char.join(consider_keys)
             config_val = self._get_config_for_key(key=key,
                                                   key_to_search=joined_key,
                                                   default=default,

--- a/gestalt/provider.py
+++ b/gestalt/provider.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Dict, Any, Optional
+from typing import Tuple, Dict, Any, Optional, Union
 
 
 class Provider(metaclass=ABCMeta):
@@ -15,7 +15,7 @@ class Provider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get(self, key: str, path: str, filter: str, sep: Optional[str]) -> Any:
+    def get(self, key: str, path: str, filter: str, sep: Optional[str]) -> Union[str, int, float, bool]:
         """Abstract method to get a value from the provider
         """
         pass

--- a/gestalt/provider.py
+++ b/gestalt/provider.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Any, Optional
 
 
 class Provider(metaclass=ABCMeta):
@@ -15,7 +15,7 @@ class Provider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get(self, key: str, path: str, filter: str) -> Any:
+    def get(self, key: str, path: str, filter: str, sep: Optional[str]) -> Any:
         """Abstract method to get a value from the provider
         """
         pass

--- a/gestalt/provider.py
+++ b/gestalt/provider.py
@@ -19,3 +19,10 @@ class Provider(metaclass=ABCMeta):
         """Abstract method to get a value from the provider
         """
         pass
+
+    @property
+    @abstractmethod
+    def scheme(self) -> str:
+        """Returns scheme of provider
+        """
+        pass

--- a/gestalt/provider.py
+++ b/gestalt/provider.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Dict, Any, Optional, Union, List[Any]
+from typing import Tuple, Dict, Any, Optional, Union, List
 
 
 class Provider(metaclass=ABCMeta):

--- a/gestalt/provider.py
+++ b/gestalt/provider.py
@@ -15,7 +15,8 @@ class Provider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get(self, key: str, path: str, filter: str, sep: Optional[str]) -> Union[str, int, float, bool, List[Any]]:
+    def get(self, key: str, path: str, filter: str,
+            sep: Optional[str]) -> Union[str, int, float, bool, List[Any]]:
         """Abstract method to get a value from the provider
         """
         pass

--- a/gestalt/provider.py
+++ b/gestalt/provider.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Dict, Any, Optional, Union
+from typing import Tuple, Dict, Any, Optional, Union, List[Any]
 
 
 class Provider(metaclass=ABCMeta):
@@ -15,7 +15,7 @@ class Provider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get(self, key: str, path: str, filter: str, sep: Optional[str]) -> Union[str, int, float, bool]:
+    def get(self, key: str, path: str, filter: str, sep: Optional[str]) -> Union[str, int, float, bool, List[Any]]:
         """Abstract method to get a value from the provider
         """
         pass

--- a/gestalt/utils.py
+++ b/gestalt/utils.py
@@ -1,0 +1,17 @@
+from typing import MutableMapping, Text, Any, Union, Dict, List
+import collections.abc as collections
+
+
+def flatten(
+        d: MutableMapping[Text, Any],
+        parent_key: str = '',
+        sep: str = '.'
+) -> Dict[Text, Union[List[Any], Text, int, bool, float]]:
+    items: List[Any] = []
+    for k, v in d.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, collections.MutableMapping):
+            items.extend(flatten(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)

--- a/gestalt/utils.py
+++ b/gestalt/utils.py
@@ -3,9 +3,9 @@ import collections.abc as collections
 
 
 def flatten(
-        d: MutableMapping[Text, Any],
-        parent_key: str = '',
-        sep: str = '.'
+    d: MutableMapping[Text, Any],
+    parent_key: str = '',
+    sep: str = '.'
 ) -> Dict[Text, Union[List[Any], Text, int, bool, float]]:
     items: List[Any] = []
     for k, v in d.items():

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -11,7 +11,7 @@ from threading import Thread
 from retry import retry
 
 
-def _get_nested_key(requested_data: Dict, key: str, sep: str) -> Any:
+def _get_nested_key(requested_data: Dict[str, Any], key: str, sep: str) -> Any:
     for nested_key in key.split(sep):
         requested_data = requested_data[nested_key]
     return requested_data
@@ -148,7 +148,7 @@ class Vault(Provider):
             print(f"TTL key {key} found expired.")
         return is_expired
 
-    def _set_secrets_ttl(self, requested_data: Dict, key: str) -> None:
+    def _set_secrets_ttl(self, requested_data: Dict[str, Any], key: str) -> None:
         last_vault_rotation_str = requested_data["last_vault_rotation"].split(".")[0]  # to the nearest second
         last_vault_rotation_dt = datetime.strptime(last_vault_rotation_str, '%Y-%m-%dT%H:%M:%S')
         ttl = requested_data["ttl"]

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -45,7 +45,8 @@ class Vault(Provider):
                                         cert=cert,
                                         verify=verify)
         self._secret_expiry_times: Dict[str, datetime] = dict()
-        self._secret_values: Dict[str, Union[str, int, float, bool, List[Any]]] = dict()
+        self._secret_values: Dict[str, Union[str, int, float, bool,
+                                             List[Any]]] = dict()
 
         try:
             self.vault_client.is_authenticated()
@@ -84,7 +85,13 @@ class Vault(Provider):
             kubernetes_ttl_renew.start()
 
     @retry(RuntimeError, delay=3, tries=3)  # type: ignore
-    def get(self, key: str, path: str, filter: str, sep: Optional[str] = ".") -> Union[str, int, float, bool, List[Any]]:
+    def get(
+        self,
+        key: str,
+        path: str,
+        filter: str,
+        sep: Optional[str] = "."
+    ) -> Union[str, int, float, bool, List[Any]]:
         """Gets secret from vault
         Args:
             key (str): key to get secret from
@@ -100,7 +107,8 @@ class Vault(Provider):
             return self._secret_values[key]
 
         # if the secret can expire but hasn't expired yet
-        if key in self._secret_expiry_times and not self._is_secret_expired(key):
+        if key in self._secret_expiry_times and not self._is_secret_expired(
+                key):
             print(f"Found unexpired TTL key {key}. Not going to Vault.")
             return self._secret_values[key]
 
@@ -148,9 +156,12 @@ class Vault(Provider):
             print(f"TTL key {key} found expired.")
         return is_expired
 
-    def _set_secrets_ttl(self, requested_data: Dict[str, Any], key: str) -> None:
-        last_vault_rotation_str = requested_data["last_vault_rotation"].split(".")[0]  # to the nearest second
-        last_vault_rotation_dt = datetime.strptime(last_vault_rotation_str, '%Y-%m-%dT%H:%M:%S')
+    def _set_secrets_ttl(self, requested_data: Dict[str, Any],
+                         key: str) -> None:
+        last_vault_rotation_str = requested_data["last_vault_rotation"].split(
+            ".")[0]  # to the nearest second
+        last_vault_rotation_dt = datetime.strptime(last_vault_rotation_str,
+                                                   '%Y-%m-%dT%H:%M:%S')
         ttl = requested_data["ttl"]
         secret_expires_dt = last_vault_rotation_dt + timedelta(seconds=ttl)
         self._secret_expiry_times[key] = secret_expires_dt

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -45,7 +45,7 @@ class Vault(Provider):
                                         cert=cert,
                                         verify=verify)
         self._secret_expiry_times: Dict[str, datetime] = dict()
-        self._secret_values: Dict[str, Any] = dict()
+        self._secret_values: Dict[str, Union[str, int, float, bool, List[Any]]] = dict()
 
         try:
             self.vault_client.is_authenticated()

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -130,7 +130,7 @@ class Vault(Provider):
         match = jsonpath_expression.find(secret)
         if len(match) == 0:
             print("Path returned not matches for your secret")
-        returned_value_from_secret = match[0].value
+        returned_value_from_secret: Union[str, int, float, bool, List[Any]] = match[0].value
         if returned_value_from_secret == "":
             raise RuntimeError("Gestalt Error: Empty secret!")
 

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -3,7 +3,7 @@ from time import sleep
 from gestalt.provider import Provider
 import requests
 from jsonpath_ng import parse  # type: ignore
-from typing import Optional, Tuple, Any, Dict
+from typing import Optional, Tuple, Any, Dict, Union, List
 import hvac  # type: ignore
 import asyncio
 import os
@@ -84,7 +84,7 @@ class Vault(Provider):
             kubernetes_ttl_renew.start()
 
     @retry(RuntimeError, delay=3, tries=3)  # type: ignore
-    def get(self, key: str, path: str, filter: str, sep: Optional[str] = ".") -> Any:
+    def get(self, key: str, path: str, filter: str, sep: Optional[str] = ".") -> Union[str, int, float, bool, List[Any]]:
         """Gets secret from vault
         Args:
             key (str): key to get secret from

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -130,7 +130,7 @@ class Vault(Provider):
         match = jsonpath_expression.find(secret)
         if len(match) == 0:
             print("Path returned not matches for your secret")
-        returned_value_from_secret: Union[str, int, float, bool, List[Any]] = match[0].value
+        returned_value_from_secret = match[0].value
         if returned_value_from_secret == "":
             raise RuntimeError("Gestalt Error: Empty secret!")
 
@@ -138,7 +138,7 @@ class Vault(Provider):
         if "ttl" in requested_data:
             self._set_secrets_ttl(requested_data, key)
 
-        return returned_value_from_secret
+        return returned_value_from_secret  # type: ignore
 
     def _is_secret_expired(self, key: str) -> bool:
         now = datetime.now()

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -136,7 +136,7 @@ class Vault(Provider):
         secret_expires_dt = self._secret_expiry_times[key]
         is_expired = now >= secret_expires_dt
         if is_expired:
-            logger.debug(f"TTL key {key} found expired.")
+            print(f"TTL key {key} found expired.")
         return is_expired
 
     def _set_secrets_ttl(self, requested_data: Dict, key: str) -> None:

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -138,8 +138,6 @@ class Vault(Provider):
         if "ttl" in requested_data:
             self._set_secrets_ttl(requested_data, key)
 
-        print(f"THE RETURNED VALUE FROM SECRET {returned_value_from_secret}")
-
         return returned_value_from_secret
 
     def _is_secret_expired(self, key: str) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.4.0',
+      version='3.3.0',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.2.0',
+      version='3.3.0',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.3.0',
+      version='3.4.0',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch, Mock
+import pytest
+import hvac
+import os
+import requests
+
+
+class MockSession(requests.Session):
+    def request(self, *_, **__):
+        resp = {
+            'request_id': '230f5e67-e55d-bdae-bd24-c7bc13c1a3e9',
+            'lease_id': '',
+            'renewable': False,
+            'lease_duration': 0,
+            'data': {
+                'last_vault_rotation': '2023-05-31T14:24:41.724285249Z',
+                'password': 'foo',
+                'rotation_period': 60,
+                'ttl': 0,
+                'username': 'foo'
+            },
+            'wrap_info': None,
+            'warnings': None,
+            'auth': None
+        }
+        return MockResponse(resp, 200)
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.ok = True
+
+    def json(self):
+        return self.json_data
+
+
+@pytest.fixture
+def mock_db_role_request(mocker):
+    mocker.patch("requests.Session", MockSession)
+
+
+@pytest.fixture(scope="function")
+def secret_setup():
+    client = hvac.Client()
+    client.secrets.kv.v2.create_or_update_secret(
+        path="test", secret=dict(test_secret="test_secret_password"))
+
+
+@pytest.fixture(scope="function")
+def incorrect_env_setup():
+    os.environ['VAULT_ADDR'] = ""
+
+
+@pytest.fixture(scope="function")
+def mount_setup():
+    client = hvac.Client()
+    secret_engines_list = client.sys.list_mounted_secrets_engines(
+    )['data'].keys()
+    if "test-mount/" in secret_engines_list:
+        client.sys.disable_secrets_engine(path="test-mount")
+    client.sys.enable_secrets_engine(backend_type="kv", path="test-mount")
+    client.secrets.kv.v2.create_or_update_secret(
+        mount_point="test-mount",
+        path="test",
+        secret=dict(test_mount="test_mount_password"))
+
+
+@pytest.fixture(scope="function")
+def nested_setup():
+    client = hvac.Client()
+    client.secrets.kv.v2.create_or_update_secret(
+        path="testnested", secret=dict(slack={"token": "random-token"}))
+
+
+@pytest.fixture
+def mock_vault_workers():
+    mock_dynamic_renew = Mock()
+    mock_k8s_renew = Mock()
+    patch("gestalt.vault.Thread",
+          side_effect=[mock_dynamic_renew, mock_k8s_renew]).start()
+    return (mock_dynamic_renew, mock_k8s_renew)
+
+
+@pytest.fixture
+def mock_vault_k8s_auth():
+    return patch("gestalt.vault.hvac.api.auth_methods.Kubernetes").start()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,5 +84,5 @@ def mock_vault_workers():
 
 
 @pytest.fixture
-def mock_vault_k8s_auth():
-    return patch("gestalt.vault.hvac.api.auth_methods.Kubernetes").start()
+def mock_vault_k8s_auth(mocker):
+    mocker.patch("gestalt.vault.hvac.api.auth_methods.Kubernetes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def mock_vault_workers():
     mock_dynamic_renew = Mock()
     mock_k8s_renew = Mock()
     with patch("gestalt.vault.Thread",
-                side_effect=[mock_dynamic_renew, mock_k8s_renew]):
+               side_effect=[mock_dynamic_renew, mock_k8s_renew]):
         yield (mock_dynamic_renew, mock_k8s_renew)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,9 +78,9 @@ def nested_setup():
 def mock_vault_workers():
     mock_dynamic_renew = Mock()
     mock_k8s_renew = Mock()
-    patch("gestalt.vault.Thread",
-          side_effect=[mock_dynamic_renew, mock_k8s_renew]).start()
-    return (mock_dynamic_renew, mock_k8s_renew)
+    with patch("gestalt.vault.Thread",
+                side_effect=[mock_dynamic_renew, mock_k8s_renew]):
+        yield (mock_dynamic_renew, mock_k8s_renew)
 
 
 @pytest.fixture

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -1,644 +1,644 @@
-# type: ignore
-
-from unittest.mock import patch, Mock
-
-from gestalt.vault import Vault
-from gestalt import merge_into
-import asyncio
-import pytest
-import os
-import gestalt
-import hvac
-
-
-# Testing member function
-def test_merge_into():
-    combine1 = {}
-    combine2 = {}
-    combine3 = {"local": 1234, "pg": {"host": "dict1_pg", "pass": "dict1_pg"}}
-    combine4 = {"local": 1234, "pg": {"host": "dict2_pg"}}
-
-    merge_into(combine3, combine1)
-    merge_into(combine4, combine1)
-
-    merge_into(combine4, combine2)
-    merge_into(combine3, combine2)
-
-    assert combine1 == {
-        "local": 1234,
-        "pg": {
-            "host": "dict2_pg",
-            "pass": "dict1_pg"
-        }
-    }
-
-    assert combine2 == {
-        "local": 1234,
-        "pg": {
-            "host": "dict1_pg",
-            "pass": "dict1_pg"
-        }
-    }
-
-
-def test_combine_into_empty_dict():
-    combine = {}
-    merge_into({}, combine)
-    assert combine == {}
-
-    combine = {"local": 1234}
-    merge_into({}, combine)
-    assert combine == {"local": 1234}
-
-
-# Testing JSON Loading
-def test_loading_json():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    x = g.dump()
-    assert len(x)
-
-
-def test_loading_json_file():
-    g = gestalt.Gestalt()
-    g.add_config_file('./tests/testdata/testjson.json')
-    g.build_config()
-    x = g.dump()
-    assert len(x)
-
-
-def test_loading_file_dir():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_file('./tests/testdata')
-        assert 'is not a file' in terr
-
-
-def test_loading_file_nonexist():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_file('./tests/testdata/nothere.yaml')
-        g.build_config()
-        assert 'is not a file' in terr
-
-
-def test_loading_file_bad_yaml():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_file('./tests/testdatabad/testyaml.yaml')
-        g.build_config()
-        assert terr.type is ValueError
-        assert 'but cannot be read as such' in terr.value.args[0]
-
-
-def test_loading_file_bad_json():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_file('./tests/testdatabad/testjson.json')
-        g.build_config()
-        assert terr.type is ValueError
-        assert 'but cannot be read as such' in terr.value.args[0]
-
-
-def test_loading_dir_bad_files():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_path('./tests/testdatabad')
-        g.build_config()
-        assert terr.type is ValueError
-        assert 'but cannot be read as such' in terr.value.args[0]
-
-
-def test_loading_dir_bad_files_yaml_only():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_path('./tests/testdatabadyaml')
-        g.build_config()
-        assert terr.type is ValueError
-        assert 'but cannot be read as such' in terr.value.args[0]
-
-
-def test_loading_yaml_file():
-    g = gestalt.Gestalt()
-    g.add_config_file('./tests/testdata/testyaml.yaml')
-    g.build_config()
-    x = g.dump()
-    assert len(x)
-
-
-def test_loading_json_nonexist_dir():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_path('./nonexistpath')
-        assert 'does not exist' in terr
-
-
-def test_loading_json_file_not_dir():
-    g = gestalt.Gestalt()
-    with pytest.raises(ValueError) as terr:
-        g.add_config_path('./setup.py')
-        assert 'is not a directory' in terr
-
-
-def test_get_wrong_type():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    with pytest.raises(TypeError) as terr:
-        g.get_string('numbers')
-        assert 'is not of type' in terr
-
-
-def test_get_non_exist_key():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    with pytest.raises(ValueError) as terr:
-        g.get_string('non-exist')
-        assert 'is not in any configuration and no default is provided' in terr
-
-
-def test_get_key_wrong_type():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    with pytest.raises(TypeError) as terr:
-        g.get_string(1234)
-        assert 'is not of string type' in terr
-
-
-def test_get_key_wrong_default_type():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    with pytest.raises(TypeError) as terr:
-        g.get_string('nonexist', 1234)
-        assert 'Provided default is of incorrect type' in terr
-
-
-def test_get_json_string():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_string('yarn')
-    assert testval == 'blue skies'
-
-
-def test_get_json_default_string():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_string('nonexist', 'mydefval')
-    assert testval == 'mydefval'
-
-
-def test_get_json_set_default_string():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    g.set_default_string('nonexisttest', 'otherdefval')
-    testval = g.get_string('nonexisttest')
-    assert testval == 'otherdefval'
-
-
-def test_get_json_int():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_int('numbers')
-    assert testval == 12345678
-
-
-def test_get_json_float():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_float('strangenumbers')
-    assert testval == 123.456
-
-
-def test_get_json_bool():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_bool('truthy')
-    assert testval is True
-
-
-def test_get_json_list():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_list('listing')
-    assert testval
-    assert 'dog' in testval
-    assert 'cat' in testval
-
-
-def test_get_json_nested():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_string('deep.nested1')
-    assert testval == 'hello'
-
-
-def test_get_yaml_nested():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_string('deep_yaml.nest1.nest2.foo')
-    assert testval == 'hello'
-
-
-# Test Set Overriding
-def test_set_string():
-    g = gestalt.Gestalt()
-    g.set_string('mykey', 'myval')
-    testval = g.get_string('mykey')
-    assert testval == 'myval'
-
-
-def test_set_int():
-    g = gestalt.Gestalt()
-    g.set_int('mykey', 1234)
-    testval = g.get_int('mykey')
-    assert testval == 1234
-
-
-def test_set_float():
-    g = gestalt.Gestalt()
-    g.set_float('mykey', 45.23)
-    testval = g.get_float('mykey')
-    assert testval == 45.23
-
-
-def test_set_bool():
-    g = gestalt.Gestalt()
-    g.set_bool('mykey', False)
-    testval = g.get_bool('mykey')
-    assert testval is False
-
-
-def test_set_list():
-    g = gestalt.Gestalt()
-    g.set_list('mykey', ['hi', 'bye'])
-    testval = g.get_list('mykey')
-    assert testval
-    assert 'hi' in testval
-    assert 'bye' in testval
-
-
-def test_set_int_get_bad():
-    g = gestalt.Gestalt()
-    g.set_int('mykey', 1234)
-    with pytest.raises(TypeError) as terr:
-        g.get_string('mykey')
-        assert 'Given set key is not of type' in terr
-
-
-def test_set_bad_key_type():
-    g = gestalt.Gestalt()
-    with pytest.raises(TypeError) as terr:
-        g.set_string(1234, 'myval')
-        assert 'is not of string type' in terr
-
-
-def test_set_bad_type():
-    g = gestalt.Gestalt()
-    with pytest.raises(TypeError) as terr:
-        g.set_string('mykey', 123)
-        assert 'is not of type' in terr
-
-
-def test_re_set_bad_type():
-    g = gestalt.Gestalt()
-    g.set_string('mykey', '123')
-    with pytest.raises(TypeError) as terr:
-        g.set_int('mykey', 123)
-        assert 'Overriding key' in terr
-
-
-def test_set_override():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    testval = g.get_int('numbers')
-    assert testval == 12345678
-    g.set_int('numbers', 6543)
-    testval = g.get_int('numbers')
-    assert testval == 6543
-
-
-def test_set_bad_type_file_config():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    with pytest.raises(TypeError) as terr:
-        g.set_string('numbers', 'notgood')
-        assert 'File config has' in terr
-
-
-def test_set_bad_type_default_config():
-    g = gestalt.Gestalt()
-    g.set_default_string('mykey', 'mystring')
-    with pytest.raises(TypeError) as terr:
-        g.set_int('mykey', 123)
-        assert 'Default config has' in terr
-
-
-# Test Env Variables
-def test_get_env_string():
-    g = gestalt.Gestalt()
-    g.auto_env()
-    os.environ['MYKEY'] = 'myval'
-    testval = g.get_string('mykey')
-    assert testval == 'myval'
-
-
-def test_get_env_int():
-    g = gestalt.Gestalt()
-    g.auto_env()
-    os.environ['MYKEY'] = '999'
-    testval = g.get_int('mykey')
-    assert testval == 999
-
-
-def test_get_nested_env_string():
-    g = gestalt.Gestalt()
-    g.auto_env()
-    os.environ['MY_KEY'] = 'myval'
-    testval = g.get_string('my.key')
-    assert testval == 'myval'
-
-
-def test_get_env_bad_type():
-    g = gestalt.Gestalt()
-    g.auto_env()
-    os.environ['MY_KEY'] = 'myval'
-    with pytest.raises(TypeError) as terr:
-        g.get_int('my.key')
-        assert "could not be converted to type" in terr
-
-
-# Test Default Values
-def test_set_default_string():
-    g = gestalt.Gestalt()
-    g.set_default_string('mykey', 'myval')
-    testval = g.get_string('mykey')
-    assert testval == 'myval'
-
-
-def test_set_default_int():
-    g = gestalt.Gestalt()
-    g.set_default_int('mykey', 1234)
-    testval = g.get_int('mykey')
-    assert testval == 1234
-
-
-def test_set_default_float():
-    g = gestalt.Gestalt()
-    g.set_default_float('mykey', 1234.05)
-    testval = g.get_float('mykey')
-    assert testval == 1234.05
-
-
-def test_set_default_bool():
-    g = gestalt.Gestalt()
-    g.set_default_bool('mykey', False)
-    testval = g.get_bool('mykey')
-    assert testval is False
-
-
-def test_set_default_list():
-    g = gestalt.Gestalt()
-    g.set_default_list('mykey', ['bear', 'bull'])
-    testval = g.get_list('mykey')
-    assert testval
-    assert 'bear' in testval
-    assert 'bull' in testval
-
-
-def test_set_default_int_get_bad():
-    g = gestalt.Gestalt()
-    g.set_default_int('mykey', 1234)
-    with pytest.raises(TypeError) as terr:
-        g.get_string('mykey')
-        assert 'Given default set key is not of type' in terr
-
-
-def test_set_default_string_bad_key():
-    g = gestalt.Gestalt()
-    with pytest.raises(TypeError) as terr:
-        g.set_default_string(1234, 'myval')
-        assert 'Given key is not of string type' in terr
-
-
-def test_set_default_string_bad_val():
-    g = gestalt.Gestalt()
-    with pytest.raises(TypeError) as terr:
-        g.set_default_string('mykey', 123)
-        assert 'Input value when setting default' in terr
-
-
-def test_set_default_string_bad_val_override():
-    g = gestalt.Gestalt()
-    with pytest.raises(TypeError) as terr:
-        g.set_default_string('mykey', 'myval')
-        g.set_default_int('mykey', 1234)
-        assert 'Overriding default key' in terr
-
-
-def test_override_nested_config():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testoverride/')
-    g.build_config()
-    assert g.get_int("local") == 123456
-    assert g.get_string("nested1.nested2") == "final"
-    assert g.get_string("pg.host") == "dev_host"
-    assert g.get_string("pg.pass") == "def_pass"
-    assert g.get_string("nested1.nested3.nested4.deeplevel") == "nested5"
-
-
-def test_set_default_bad_type_file_config():
-    g = gestalt.Gestalt()
-    g.add_config_path('./tests/testdata')
-    g.build_config()
-    with pytest.raises(TypeError) as terr:
-        g.set_default_string('numbers', 'notgood')
-        assert 'File config has' in terr
-
-
-def test_set_default_bad_type_set_config():
-    g = gestalt.Gestalt()
-    g.set_string('mykey', 'mystring')
-    with pytest.raises(TypeError) as terr:
-        g.set_default_int('mykey', 123)
-        assert 'Set config has' in terr
-
-
-def test_vault_setup():
-    vault = Vault(role=None, jwt=None)
-    assert vault.vault_client.is_authenticated() is True
-
-
-def test_vault_interpolation(secret_setup):
-    g = gestalt.Gestalt()
-    g.add_config_file("./tests/testvault/testcorrect.json")
-    vault = Vault(role=None, jwt=None)
-    g.configure_provider("vault", vault)
-    g.build_config()
-    secret = g.get_string("test_secret.test_secret")
-    assert secret == "test_secret_password"
-
-
-def test_vault_mount_path(mount_setup):
-    g = gestalt.Gestalt()
-    g.add_config_file("./tests/testvault/testmount.json")
-    g.configure_provider("vault", Vault(role=None, jwt=None))
-    g.build_config()
-    secret = g.get_string("test_mount.test_mount")
-    assert secret == "test_mount_password"
-
-
-def test_vault_incorrect_path(mount_setup):
-    g = gestalt.Gestalt()
-    g.add_config_file("./tests/testvault/testincorrectmount.json")
-    g.configure_provider("vault", Vault(role=None, jwt=None))
-    with pytest.raises(RuntimeError):
-        g.build_config()
-        g.get_string("test_mount")
-
-
-def test_nest_key_for_vault(nested_setup, secret_setup):
-    g = gestalt.Gestalt()
-    g.add_config_file("./tests/testvault/testnested.json")
-    g.configure_provider("vault", Vault(role=None, jwt=None))
-    g.build_config()
-    secret_db = g.get_string("remoteAPI.database.test_secret")
-    secret_slack = g.get_string("remoteAPI.slack.token")
-    assert secret_db == "test_secret_password"
-    assert secret_slack == "random-token"
-
-
-def test_read_no_nest_db_role(mock_db_role_request):
-    g = gestalt.Gestalt()
-    g.add_config_file("./tests/testvault/testsfdynamic.json")
-    g.configure_provider("vault", Vault(role=None, jwt=None))
-    g.build_config()
-    secret_username = g.get_string("username")
-    assert secret_username == "foo"
-
-
-def test_set_vault_key(nested_setup):
-    g = gestalt.Gestalt()
-    g.configure_provider("vault", Vault(role=None, jwt=None))
-    g.set_string(key="test",
-                 value="ref+vault://secret/data/testnested#.slack.token")
-    g.build_config()
-    secret = g.get_string("test")
-    assert secret == "ref+vault://secret/data/testnested#.slack.token"
-
-
-@pytest.mark.asyncio
-async def test_vault_worker_dynamic(mock_vault_workers, mock_vault_k8s_auth):
-    mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
-
-    mock_sleep = None
-
-    def except_once(self, **kwargs):
-        # side effect used to exit the worker loop after one call
-        if mock_sleep.call_count == 1:
-            raise hvac.exceptions.VaultError("some error")
-
-    with patch("gestalt.vault.sleep", side_effect=except_once,
-               autospec=True) as mock_sleep:
-
-        with patch("gestalt.vault.hvac.Client") as mock_client:
-            v = Vault(role="test-role", jwt="test-jwt")
-
-            mock_k8s_renew.start.assert_called()
-
-            test_token_queue = asyncio.Queue(maxsize=0)
-            await test_token_queue.put(("dynamic", 1, 100))
-
-            with pytest.raises(RuntimeError):
-                await v.worker(test_token_queue)
-
-            mock_sleep.assert_called()
-            mock_client().sys.renew_lease.assert_called()
-            mock_k8s_renew.start.assert_called_once()
-
-            mock_vault_k8s_auth.stop()
-            mock_dynamic_renew.stop()
-            mock_k8s_renew.stop()
-
-
-@pytest.mark.asyncio
-async def test_vault_worker_k8s(mock_vault_workers):
-    mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
-
-    mock_sleep = None
-
-    def except_once(self, **kwargs):
-        # side effect used to exit the worker loop after one call
-        if mock_sleep.call_count == 1:
-            raise hvac.exceptions.VaultError("some error")
-
-    with patch("gestalt.vault.sleep", side_effect=except_once,
-               autospec=True) as mock_sleep:
-        with patch("gestalt.vault.hvac.Client") as mock_client:
-            v = Vault(role="test-role", jwt="test-jwt")
-
-            mock_k8s_renew.start.assert_called()
-
-            test_token_queue = asyncio.Queue(maxsize=0)
-            await test_token_queue.put(("kubernetes", 1, 100))
-
-            with pytest.raises(RuntimeError):
-                await v.worker(test_token_queue)
-
-            mock_sleep.assert_called()
-            mock_client().auth.token.renew.assert_called()
-            mock_k8s_renew.start.assert_called_once()
-
-            mock_dynamic_renew.stop()
-            mock_k8s_renew.stop()
-
-
-@pytest.mark.asyncio
-async def test_vault_start_dynamic_lease(mock_vault_workers):
-    mock_response = {
-        "lease_id": "1",
-        "lease_duration": 5,
-        "data": {
-            "data": "mock_data"
-        }
-    }
-    mock_vault_client_read = patch("gestalt.vault.hvac.Client.read",
-                                   return_value=mock_response).start()
-
-    mock_dynamic_token_queue = Mock()
-    mock_kube_token_queue = Mock()
-    mock_queues = patch(
-        "gestalt.vault.asyncio.Queue",
-        side_effect=[mock_dynamic_token_queue, mock_kube_token_queue]).start()
-
-    v = Vault(role=None, jwt=None)
-    g = gestalt.Gestalt()
-    g.add_config_file("./tests/testvault/testmount.json")
-    g.configure_provider("vault", v)
-    g.build_config()
-    g.get_string("test_mount")
-
-    mock_vault_client_read.assert_called()
-    mock_dynamic_token_queue.put_nowait.assert_called()
-
-    mock_vault_client_read.stop()
-    mock_dynamic_token_queue.stop()
-    mock_kube_token_queue.stop()
-    mock_queues.stop()
-    mock_vault_client_read.stop()
-
-
+# # type: ignore
+#
+# from unittest.mock import patch, Mock
+#
+# from gestalt.vault import Vault
+# from gestalt import merge_into
+# import asyncio
+# import pytest
+# import os
+# import gestalt
+# import hvac
+#
+#
+# # Testing member function
+# def test_merge_into():
+#     combine1 = {}
+#     combine2 = {}
+#     combine3 = {"local": 1234, "pg": {"host": "dict1_pg", "pass": "dict1_pg"}}
+#     combine4 = {"local": 1234, "pg": {"host": "dict2_pg"}}
+#
+#     merge_into(combine3, combine1)
+#     merge_into(combine4, combine1)
+#
+#     merge_into(combine4, combine2)
+#     merge_into(combine3, combine2)
+#
+#     assert combine1 == {
+#         "local": 1234,
+#         "pg": {
+#             "host": "dict2_pg",
+#             "pass": "dict1_pg"
+#         }
+#     }
+#
+#     assert combine2 == {
+#         "local": 1234,
+#         "pg": {
+#             "host": "dict1_pg",
+#             "pass": "dict1_pg"
+#         }
+#     }
+#
+#
+# def test_combine_into_empty_dict():
+#     combine = {}
+#     merge_into({}, combine)
+#     assert combine == {}
+#
+#     combine = {"local": 1234}
+#     merge_into({}, combine)
+#     assert combine == {"local": 1234}
+#
+#
+# # Testing JSON Loading
+# def test_loading_json():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     x = g.dump()
+#     assert len(x)
+#
+#
+# def test_loading_json_file():
+#     g = gestalt.Gestalt()
+#     g.add_config_file('./tests/testdata/testjson.json')
+#     g.build_config()
+#     x = g.dump()
+#     assert len(x)
+#
+#
+# def test_loading_file_dir():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_file('./tests/testdata')
+#         assert 'is not a file' in terr
+#
+#
+# def test_loading_file_nonexist():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_file('./tests/testdata/nothere.yaml')
+#         g.build_config()
+#         assert 'is not a file' in terr
+#
+#
+# def test_loading_file_bad_yaml():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_file('./tests/testdatabad/testyaml.yaml')
+#         g.build_config()
+#         assert terr.type is ValueError
+#         assert 'but cannot be read as such' in terr.value.args[0]
+#
+#
+# def test_loading_file_bad_json():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_file('./tests/testdatabad/testjson.json')
+#         g.build_config()
+#         assert terr.type is ValueError
+#         assert 'but cannot be read as such' in terr.value.args[0]
+#
+#
+# def test_loading_dir_bad_files():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_path('./tests/testdatabad')
+#         g.build_config()
+#         assert terr.type is ValueError
+#         assert 'but cannot be read as such' in terr.value.args[0]
+#
+#
+# def test_loading_dir_bad_files_yaml_only():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_path('./tests/testdatabadyaml')
+#         g.build_config()
+#         assert terr.type is ValueError
+#         assert 'but cannot be read as such' in terr.value.args[0]
+#
+#
+# def test_loading_yaml_file():
+#     g = gestalt.Gestalt()
+#     g.add_config_file('./tests/testdata/testyaml.yaml')
+#     g.build_config()
+#     x = g.dump()
+#     assert len(x)
+#
+#
+# def test_loading_json_nonexist_dir():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_path('./nonexistpath')
+#         assert 'does not exist' in terr
+#
+#
+# def test_loading_json_file_not_dir():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(ValueError) as terr:
+#         g.add_config_path('./setup.py')
+#         assert 'is not a directory' in terr
+#
+#
+# def test_get_wrong_type():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     with pytest.raises(TypeError) as terr:
+#         g.get_string('numbers')
+#         assert 'is not of type' in terr
+#
+#
+# def test_get_non_exist_key():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     with pytest.raises(ValueError) as terr:
+#         g.get_string('non-exist')
+#         assert 'is not in any configuration and no default is provided' in terr
+#
+#
+# def test_get_key_wrong_type():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     with pytest.raises(TypeError) as terr:
+#         g.get_string(1234)
+#         assert 'is not of string type' in terr
+#
+#
+# def test_get_key_wrong_default_type():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     with pytest.raises(TypeError) as terr:
+#         g.get_string('nonexist', 1234)
+#         assert 'Provided default is of incorrect type' in terr
+#
+#
+# def test_get_json_string():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_string('yarn')
+#     assert testval == 'blue skies'
+#
+#
+# def test_get_json_default_string():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_string('nonexist', 'mydefval')
+#     assert testval == 'mydefval'
+#
+#
+# def test_get_json_set_default_string():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     g.set_default_string('nonexisttest', 'otherdefval')
+#     testval = g.get_string('nonexisttest')
+#     assert testval == 'otherdefval'
+#
+#
+# def test_get_json_int():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_int('numbers')
+#     assert testval == 12345678
+#
+#
+# def test_get_json_float():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_float('strangenumbers')
+#     assert testval == 123.456
+#
+#
+# def test_get_json_bool():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_bool('truthy')
+#     assert testval is True
+#
+#
+# def test_get_json_list():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_list('listing')
+#     assert testval
+#     assert 'dog' in testval
+#     assert 'cat' in testval
+#
+#
+# def test_get_json_nested():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_string('deep.nested1')
+#     assert testval == 'hello'
+#
+#
+# def test_get_yaml_nested():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_string('deep_yaml.nest1.nest2.foo')
+#     assert testval == 'hello'
+#
+#
+# # Test Set Overriding
+# def test_set_string():
+#     g = gestalt.Gestalt()
+#     g.set_string('mykey', 'myval')
+#     testval = g.get_string('mykey')
+#     assert testval == 'myval'
+#
+#
+# def test_set_int():
+#     g = gestalt.Gestalt()
+#     g.set_int('mykey', 1234)
+#     testval = g.get_int('mykey')
+#     assert testval == 1234
+#
+#
+# def test_set_float():
+#     g = gestalt.Gestalt()
+#     g.set_float('mykey', 45.23)
+#     testval = g.get_float('mykey')
+#     assert testval == 45.23
+#
+#
+# def test_set_bool():
+#     g = gestalt.Gestalt()
+#     g.set_bool('mykey', False)
+#     testval = g.get_bool('mykey')
+#     assert testval is False
+#
+#
+# def test_set_list():
+#     g = gestalt.Gestalt()
+#     g.set_list('mykey', ['hi', 'bye'])
+#     testval = g.get_list('mykey')
+#     assert testval
+#     assert 'hi' in testval
+#     assert 'bye' in testval
+#
+#
+# def test_set_int_get_bad():
+#     g = gestalt.Gestalt()
+#     g.set_int('mykey', 1234)
+#     with pytest.raises(TypeError) as terr:
+#         g.get_string('mykey')
+#         assert 'Given set key is not of type' in terr
+#
+#
+# def test_set_bad_key_type():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(TypeError) as terr:
+#         g.set_string(1234, 'myval')
+#         assert 'is not of string type' in terr
+#
+#
+# def test_set_bad_type():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(TypeError) as terr:
+#         g.set_string('mykey', 123)
+#         assert 'is not of type' in terr
+#
+#
+# def test_re_set_bad_type():
+#     g = gestalt.Gestalt()
+#     g.set_string('mykey', '123')
+#     with pytest.raises(TypeError) as terr:
+#         g.set_int('mykey', 123)
+#         assert 'Overriding key' in terr
+#
+#
+# def test_set_override():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     testval = g.get_int('numbers')
+#     assert testval == 12345678
+#     g.set_int('numbers', 6543)
+#     testval = g.get_int('numbers')
+#     assert testval == 6543
+#
+#
+# def test_set_bad_type_file_config():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     with pytest.raises(TypeError) as terr:
+#         g.set_string('numbers', 'notgood')
+#         assert 'File config has' in terr
+#
+#
+# def test_set_bad_type_default_config():
+#     g = gestalt.Gestalt()
+#     g.set_default_string('mykey', 'mystring')
+#     with pytest.raises(TypeError) as terr:
+#         g.set_int('mykey', 123)
+#         assert 'Default config has' in terr
+#
+#
+# # Test Env Variables
+# def test_get_env_string():
+#     g = gestalt.Gestalt()
+#     g.auto_env()
+#     os.environ['MYKEY'] = 'myval'
+#     testval = g.get_string('mykey')
+#     assert testval == 'myval'
+#
+#
+# def test_get_env_int():
+#     g = gestalt.Gestalt()
+#     g.auto_env()
+#     os.environ['MYKEY'] = '999'
+#     testval = g.get_int('mykey')
+#     assert testval == 999
+#
+#
+# def test_get_nested_env_string():
+#     g = gestalt.Gestalt()
+#     g.auto_env()
+#     os.environ['MY_KEY'] = 'myval'
+#     testval = g.get_string('my.key')
+#     assert testval == 'myval'
+#
+#
+# def test_get_env_bad_type():
+#     g = gestalt.Gestalt()
+#     g.auto_env()
+#     os.environ['MY_KEY'] = 'myval'
+#     with pytest.raises(TypeError) as terr:
+#         g.get_int('my.key')
+#         assert "could not be converted to type" in terr
+#
+#
+# # Test Default Values
+# def test_set_default_string():
+#     g = gestalt.Gestalt()
+#     g.set_default_string('mykey', 'myval')
+#     testval = g.get_string('mykey')
+#     assert testval == 'myval'
+#
+#
+# def test_set_default_int():
+#     g = gestalt.Gestalt()
+#     g.set_default_int('mykey', 1234)
+#     testval = g.get_int('mykey')
+#     assert testval == 1234
+#
+#
+# def test_set_default_float():
+#     g = gestalt.Gestalt()
+#     g.set_default_float('mykey', 1234.05)
+#     testval = g.get_float('mykey')
+#     assert testval == 1234.05
+#
+#
+# def test_set_default_bool():
+#     g = gestalt.Gestalt()
+#     g.set_default_bool('mykey', False)
+#     testval = g.get_bool('mykey')
+#     assert testval is False
+#
+#
+# def test_set_default_list():
+#     g = gestalt.Gestalt()
+#     g.set_default_list('mykey', ['bear', 'bull'])
+#     testval = g.get_list('mykey')
+#     assert testval
+#     assert 'bear' in testval
+#     assert 'bull' in testval
+#
+#
+# def test_set_default_int_get_bad():
+#     g = gestalt.Gestalt()
+#     g.set_default_int('mykey', 1234)
+#     with pytest.raises(TypeError) as terr:
+#         g.get_string('mykey')
+#         assert 'Given default set key is not of type' in terr
+#
+#
+# def test_set_default_string_bad_key():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(TypeError) as terr:
+#         g.set_default_string(1234, 'myval')
+#         assert 'Given key is not of string type' in terr
+#
+#
+# def test_set_default_string_bad_val():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(TypeError) as terr:
+#         g.set_default_string('mykey', 123)
+#         assert 'Input value when setting default' in terr
+#
+#
+# def test_set_default_string_bad_val_override():
+#     g = gestalt.Gestalt()
+#     with pytest.raises(TypeError) as terr:
+#         g.set_default_string('mykey', 'myval')
+#         g.set_default_int('mykey', 1234)
+#         assert 'Overriding default key' in terr
+#
+#
+# def test_override_nested_config():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testoverride/')
+#     g.build_config()
+#     assert g.get_int("local") == 123456
+#     assert g.get_string("nested1.nested2") == "final"
+#     assert g.get_string("pg.host") == "dev_host"
+#     assert g.get_string("pg.pass") == "def_pass"
+#     assert g.get_string("nested1.nested3.nested4.deeplevel") == "nested5"
+#
+#
+# def test_set_default_bad_type_file_config():
+#     g = gestalt.Gestalt()
+#     g.add_config_path('./tests/testdata')
+#     g.build_config()
+#     with pytest.raises(TypeError) as terr:
+#         g.set_default_string('numbers', 'notgood')
+#         assert 'File config has' in terr
+#
+#
+# def test_set_default_bad_type_set_config():
+#     g = gestalt.Gestalt()
+#     g.set_string('mykey', 'mystring')
+#     with pytest.raises(TypeError) as terr:
+#         g.set_default_int('mykey', 123)
+#         assert 'Set config has' in terr
+#
+#
+# def test_vault_setup():
+#     vault = Vault(role=None, jwt=None)
+#     assert vault.vault_client.is_authenticated() is True
+#
+#
+# def test_vault_interpolation(secret_setup):
+#     g = gestalt.Gestalt()
+#     g.add_config_file("./tests/testvault/testcorrect.json")
+#     vault = Vault(role=None, jwt=None)
+#     g.configure_provider("vault", vault)
+#     g.build_config()
+#     secret = g.get_string("test_secret.test_secret")
+#     assert secret == "test_secret_password"
+#
+#
+# def test_vault_mount_path(mount_setup):
+#     g = gestalt.Gestalt()
+#     g.add_config_file("./tests/testvault/testmount.json")
+#     g.configure_provider("vault", Vault(role=None, jwt=None))
+#     g.build_config()
+#     secret = g.get_string("test_mount.test_mount")
+#     assert secret == "test_mount_password"
+#
+#
+# def test_vault_incorrect_path(mount_setup):
+#     g = gestalt.Gestalt()
+#     g.add_config_file("./tests/testvault/testincorrectmount.json")
+#     g.configure_provider("vault", Vault(role=None, jwt=None))
+#     with pytest.raises(RuntimeError):
+#         g.build_config()
+#         g.get_string("test_mount")
+#
+#
+# def test_nest_key_for_vault(nested_setup, secret_setup):
+#     g = gestalt.Gestalt()
+#     g.add_config_file("./tests/testvault/testnested.json")
+#     g.configure_provider("vault", Vault(role=None, jwt=None))
+#     g.build_config()
+#     secret_db = g.get_string("remoteAPI.database.test_secret")
+#     secret_slack = g.get_string("remoteAPI.slack.token")
+#     assert secret_db == "test_secret_password"
+#     assert secret_slack == "random-token"
+#
+#
+# def test_read_no_nest_db_role(mock_db_role_request):
+#     g = gestalt.Gestalt()
+#     g.add_config_file("./tests/testvault/testsfdynamic.json")
+#     g.configure_provider("vault", Vault(role=None, jwt=None))
+#     g.build_config()
+#     secret_username = g.get_string("username")
+#     assert secret_username == "foo"
+#
+#
+# def test_set_vault_key(nested_setup):
+#     g = gestalt.Gestalt()
+#     g.configure_provider("vault", Vault(role=None, jwt=None))
+#     g.set_string(key="test",
+#                  value="ref+vault://secret/data/testnested#.slack.token")
+#     g.build_config()
+#     secret = g.get_string("test")
+#     assert secret == "ref+vault://secret/data/testnested#.slack.token"
+#
+#
+# @pytest.mark.asyncio
+# async def test_vault_worker_dynamic(mock_vault_workers, mock_vault_k8s_auth):
+#     mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
+#
+#     mock_sleep = None
+#
+#     def except_once(self, **kwargs):
+#         # side effect used to exit the worker loop after one call
+#         if mock_sleep.call_count == 1:
+#             raise hvac.exceptions.VaultError("some error")
+#
+#     with patch("gestalt.vault.sleep", side_effect=except_once,
+#                autospec=True) as mock_sleep:
+#
+#         with patch("gestalt.vault.hvac.Client") as mock_client:
+#             v = Vault(role="test-role", jwt="test-jwt")
+#
+#             mock_k8s_renew.start.assert_called()
+#
+#             test_token_queue = asyncio.Queue(maxsize=0)
+#             await test_token_queue.put(("dynamic", 1, 100))
+#
+#             with pytest.raises(RuntimeError):
+#                 await v.worker(test_token_queue)
+#
+#             mock_sleep.assert_called()
+#             mock_client().sys.renew_lease.assert_called()
+#             mock_k8s_renew.start.assert_called_once()
+#
+#             mock_vault_k8s_auth.stop()
+#             mock_dynamic_renew.stop()
+#             mock_k8s_renew.stop()
+#
+#
+# @pytest.mark.asyncio
+# async def test_vault_worker_k8s(mock_vault_workers):
+#     mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
+#
+#     mock_sleep = None
+#
+#     def except_once(self, **kwargs):
+#         # side effect used to exit the worker loop after one call
+#         if mock_sleep.call_count == 1:
+#             raise hvac.exceptions.VaultError("some error")
+#
+#     with patch("gestalt.vault.sleep", side_effect=except_once,
+#                autospec=True) as mock_sleep:
+#         with patch("gestalt.vault.hvac.Client") as mock_client:
+#             v = Vault(role="test-role", jwt="test-jwt")
+#
+#             mock_k8s_renew.start.assert_called()
+#
+#             test_token_queue = asyncio.Queue(maxsize=0)
+#             await test_token_queue.put(("kubernetes", 1, 100))
+#
+#             with pytest.raises(RuntimeError):
+#                 await v.worker(test_token_queue)
+#
+#             mock_sleep.assert_called()
+#             mock_client().auth.token.renew.assert_called()
+#             mock_k8s_renew.start.assert_called_once()
+#
+#             mock_dynamic_renew.stop()
+#             mock_k8s_renew.stop()
+#
+#
+# @pytest.mark.asyncio
+# async def test_vault_start_dynamic_lease(mock_vault_workers):
+#     mock_response = {
+#         "lease_id": "1",
+#         "lease_duration": 5,
+#         "data": {
+#             "data": "mock_data"
+#         }
+#     }
+#     mock_vault_client_read = patch("gestalt.vault.hvac.Client.read",
+#                                    return_value=mock_response).start()
+#
+#     mock_dynamic_token_queue = Mock()
+#     mock_kube_token_queue = Mock()
+#     mock_queues = patch(
+#         "gestalt.vault.asyncio.Queue",
+#         side_effect=[mock_dynamic_token_queue, mock_kube_token_queue]).start()
+#
+#     v = Vault(role=None, jwt=None)
+#     g = gestalt.Gestalt()
+#     g.add_config_file("./tests/testvault/testmount.json")
+#     g.configure_provider("vault", v)
+#     g.build_config()
+#     g.get_string("test_mount")
+#
+#     mock_vault_client_read.assert_called()
+#     mock_dynamic_token_queue.put_nowait.assert_called()
+#
+#     mock_vault_client_read.stop()
+#     mock_dynamic_token_queue.stop()
+#     mock_kube_token_queue.stop()
+#     mock_queues.stop()
+#     mock_vault_client_read.stop()
+#
+#

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -630,6 +630,7 @@ async def test_vault_start_dynamic_lease(mock_vault_workers):
     g.add_config_file("./tests/testvault/testmount.json")
     g.configure_provider("vault", v)
     g.build_config()
+    g.get_string("test_mount")
 
     mock_vault_client_read.assert_called()
     mock_dynamic_token_queue.put_nowait.assert_called()

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -540,105 +540,103 @@ def test_set_vault_key(nested_setup):
     secret = g.get_string("test")
     assert secret == "ref+vault://secret/data/testnested#.slack.token"
 
-#
-# @pytest.mark.asyncio
-# async def test_vault_worker_dynamic(mock_vault_workers, mock_vault_k8s_auth):
-#     mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
-#
-#     mock_sleep = None
-#
-#     def except_once(self, **kwargs):
-#         # side effect used to exit the worker loop after one call
-#         if mock_sleep.call_count == 1:
-#             raise hvac.exceptions.VaultError("some error")
-#
-#     with patch("gestalt.vault.sleep", side_effect=except_once,
-#                autospec=True) as mock_sleep:
-#
-#         with patch("gestalt.vault.hvac.Client") as mock_client:
-#             v = Vault(role="test-role", jwt="test-jwt")
-#
-#             mock_k8s_renew.start.assert_called()
-#
-#             test_token_queue = asyncio.Queue(maxsize=0)
-#             await test_token_queue.put(("dynamic", 1, 100))
-#
-#             with pytest.raises(RuntimeError):
-#                 await v.worker(test_token_queue)
-#
-#             mock_sleep.assert_called()
-#             mock_client().sys.renew_lease.assert_called()
-#             mock_k8s_renew.start.assert_called_once()
-#
-#             mock_vault_k8s_auth.stop()
-#             mock_dynamic_renew.stop()
-#             mock_k8s_renew.stop()
-#
-#
-# @pytest.mark.asyncio
-# async def test_vault_worker_k8s(mock_vault_workers):
-#     mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
-#
-#     mock_sleep = None
-#
-#     def except_once(self, **kwargs):
-#         # side effect used to exit the worker loop after one call
-#         if mock_sleep.call_count == 1:
-#             raise hvac.exceptions.VaultError("some error")
-#
-#     with patch("gestalt.vault.sleep", side_effect=except_once,
-#                autospec=True) as mock_sleep:
-#         with patch("gestalt.vault.hvac.Client") as mock_client:
-#             v = Vault(role="test-role", jwt="test-jwt")
-#
-#             mock_k8s_renew.start.assert_called()
-#
-#             test_token_queue = asyncio.Queue(maxsize=0)
-#             await test_token_queue.put(("kubernetes", 1, 100))
-#
-#             with pytest.raises(RuntimeError):
-#                 await v.worker(test_token_queue)
-#
-#             mock_sleep.assert_called()
-#             mock_client().auth.token.renew.assert_called()
-#             mock_k8s_renew.start.assert_called_once()
-#
-#             mock_dynamic_renew.stop()
-#             mock_k8s_renew.stop()
-#
-#
-# @pytest.mark.asyncio
-# async def test_vault_start_dynamic_lease(mock_vault_workers):
-#     mock_response = {
-#         "lease_id": "1",
-#         "lease_duration": 5,
-#         "data": {
-#             "data": "mock_data"
-#         }
-#     }
-#     mock_vault_client_read = patch("gestalt.vault.hvac.Client.read",
-#                                    return_value=mock_response).start()
-#
-#     mock_dynamic_token_queue = Mock()
-#     mock_kube_token_queue = Mock()
-#     mock_queues = patch(
-#         "gestalt.vault.asyncio.Queue",
-#         side_effect=[mock_dynamic_token_queue, mock_kube_token_queue]).start()
-#
-#     v = Vault(role=None, jwt=None)
-#     g = gestalt.Gestalt()
-#     g.add_config_file("./tests/testvault/testmount.json")
-#     g.configure_provider("vault", v)
-#     g.build_config()
-#     g.get_string("test_mount")
-#
-#     mock_vault_client_read.assert_called()
-#     mock_dynamic_token_queue.put_nowait.assert_called()
-#
-#     mock_vault_client_read.stop()
-#     mock_dynamic_token_queue.stop()
-#     mock_kube_token_queue.stop()
-#     mock_queues.stop()
-#     mock_vault_client_read.stop()
+
+@pytest.mark.asyncio
+async def test_vault_worker_dynamic(mock_vault_workers, mock_vault_k8s_auth):
+    mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
+
+    mock_sleep = None
+
+    def except_once(self, **kwargs):
+        # side effect used to exit the worker loop after one call
+        if mock_sleep.call_count == 1:
+            raise hvac.exceptions.VaultError("some error")
+
+    with patch("gestalt.vault.sleep", side_effect=except_once,
+               autospec=True) as mock_sleep:
+
+        with patch("gestalt.vault.hvac.Client") as mock_client:
+            v = Vault(role="test-role", jwt="test-jwt")
+
+            mock_k8s_renew.start.assert_called()
+
+            test_token_queue = asyncio.Queue(maxsize=0)
+            await test_token_queue.put(("dynamic", 1, 100))
+
+            with pytest.raises(RuntimeError):
+                await v.worker(test_token_queue)
+
+            mock_sleep.assert_called()
+            mock_client().sys.renew_lease.assert_called()
+            mock_k8s_renew.start.assert_called_once()
+
+            mock_vault_k8s_auth.stop()
+            mock_dynamic_renew.stop()
+            mock_k8s_renew.stop()
 
 
+@pytest.mark.asyncio
+async def test_vault_worker_k8s(mock_vault_workers):
+    mock_dynamic_renew, mock_k8s_renew = mock_vault_workers
+
+    mock_sleep = None
+
+    def except_once(self, **kwargs):
+        # side effect used to exit the worker loop after one call
+        if mock_sleep.call_count == 1:
+            raise hvac.exceptions.VaultError("some error")
+
+    with patch("gestalt.vault.sleep", side_effect=except_once,
+               autospec=True) as mock_sleep:
+        with patch("gestalt.vault.hvac.Client") as mock_client:
+            v = Vault(role="test-role", jwt="test-jwt")
+
+            mock_k8s_renew.start.assert_called()
+
+            test_token_queue = asyncio.Queue(maxsize=0)
+            await test_token_queue.put(("kubernetes", 1, 100))
+
+            with pytest.raises(RuntimeError):
+                await v.worker(test_token_queue)
+
+            mock_sleep.assert_called()
+            mock_client().auth.token.renew.assert_called()
+            mock_k8s_renew.start.assert_called_once()
+
+            mock_dynamic_renew.stop()
+            mock_k8s_renew.stop()
+
+
+@pytest.mark.asyncio
+async def test_vault_start_dynamic_lease(mock_vault_workers):
+    mock_response = {
+        "lease_id": "1",
+        "lease_duration": 5,
+        "data": {
+            "data": "mock_data"
+        }
+    }
+    mock_vault_client_read = patch("gestalt.vault.hvac.Client.read",
+                                   return_value=mock_response).start()
+
+    mock_dynamic_token_queue = Mock()
+    mock_kube_token_queue = Mock()
+    mock_queues = patch(
+        "gestalt.vault.asyncio.Queue",
+        side_effect=[mock_dynamic_token_queue, mock_kube_token_queue]).start()
+
+    v = Vault(role=None, jwt=None)
+    g = gestalt.Gestalt()
+    g.add_config_file("./tests/testvault/testmount.json")
+    g.configure_provider("vault", v)
+    g.build_config()
+    g.get_string("test_mount")
+
+    mock_vault_client_read.assert_called()
+    mock_dynamic_token_queue.put_nowait.assert_called()
+
+    mock_vault_client_read.stop()
+    mock_dynamic_token_queue.stop()
+    mock_kube_token_queue.stop()
+    mock_queues.stop()
+    mock_vault_client_read.stop()

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -9,43 +9,6 @@ import pytest
 import os
 import gestalt
 import hvac
-import requests
-
-
-class MockSession(requests.Session):
-    def request(self, *_, **__):
-        resp = {
-            'request_id': '230f5e67-e55d-bdae-bd24-c7bc13c1a3e9',
-            'lease_id': '',
-            'renewable': False,
-            'lease_duration': 0,
-            'data': {
-                'last_vault_rotation': '2023-05-31T14:24:41.724285249Z',
-                'password': 'foo',
-                'rotation_period': 60,
-                'ttl': 0,
-                'username': 'foo'
-            },
-            'wrap_info': None,
-            'warnings': None,
-            'auth': None
-        }
-        return MockResponse(resp, 200)
-
-
-class MockResponse:
-    def __init__(self, json_data, status_code):
-        self.json_data = json_data
-        self.status_code = status_code
-        self.ok = True
-
-    def json(self):
-        return self.json_data
-
-
-@pytest.fixture
-def mock_db_role_request(mocker):
-    mocker.patch("requests.Session", MockSession)
 
 
 # Testing member function
@@ -515,28 +478,9 @@ def test_set_default_bad_type_set_config():
         assert 'Set config has' in terr
 
 
-# Vault testing
-@pytest.fixture(scope="function")
-def env_setup():
-    os.environ['VAULT_ADDR'] = "http://localhost:8200"
-    os.environ['VAULT_TOKEN'] = "myroot"
-
-
-def test_vault_setup(env_setup):
+def test_vault_setup():
     vault = Vault(role=None, jwt=None)
     assert vault.vault_client.is_authenticated() is True
-
-
-@pytest.fixture(scope="function")
-def incorrect_env_setup():
-    os.environ['VAULT_ADDR'] = ""
-
-
-@pytest.fixture(scope="function")
-def secret_setup(env_setup):
-    client = hvac.Client()
-    client.secrets.kv.v2.create_or_update_secret(
-        path="test", secret=dict(test_secret="test_secret_password"))
 
 
 def test_vault_interpolation(secret_setup):
@@ -549,21 +493,7 @@ def test_vault_interpolation(secret_setup):
     assert secret == "test_secret_password"
 
 
-@pytest.fixture(scope="function")
-def mount_setup(env_setup):
-    client = hvac.Client()
-    secret_engines_list = client.sys.list_mounted_secrets_engines(
-    )['data'].keys()
-    if "test-mount/" in secret_engines_list:
-        client.sys.disable_secrets_engine(path="test-mount")
-    client.sys.enable_secrets_engine(backend_type="kv", path="test-mount")
-    client.secrets.kv.v2.create_or_update_secret(
-        mount_point="test-mount",
-        path="test",
-        secret=dict(test_mount="test_mount_password"))
-
-
-def test_vault_mount_path(env_setup, mount_setup):
+def test_vault_mount_path(mount_setup):
     g = gestalt.Gestalt()
     g.add_config_file("./tests/testvault/testmount.json")
     g.configure_provider("vault", Vault(role=None, jwt=None))
@@ -572,36 +502,16 @@ def test_vault_mount_path(env_setup, mount_setup):
     assert secret == "test_mount_password"
 
 
-def test_vault_incorrect_path(env_setup, mount_setup):
+def test_vault_incorrect_path(mount_setup):
     g = gestalt.Gestalt()
     g.add_config_file("./tests/testvault/testincorrectmount.json")
     g.configure_provider("vault", Vault(role=None, jwt=None))
     with pytest.raises(RuntimeError):
         g.build_config()
+        g.get_string("test_mount")
 
 
-@pytest.fixture(scope="function")
-def mount_setup(env_setup):
-    client = hvac.Client()
-    secret_engines_list = client.sys.list_mounted_secrets_engines(
-    )['data'].keys()
-    if "test-mount/" in secret_engines_list:
-        client.sys.disable_secrets_engine(path="test-mount")
-    client.sys.enable_secrets_engine(backend_type="kv", path="test-mount")
-    client.secrets.kv.v2.create_or_update_secret(
-        mount_point="test-mount",
-        path="test",
-        secret=dict(test_mount="test_mount_password"))
-
-
-@pytest.fixture(scope="function")
-def nested_setup(env_setup):
-    client = hvac.Client()
-    client.secrets.kv.v2.create_or_update_secret(
-        path="testnested", secret=dict(slack={"token": "random-token"}))
-
-
-def test_nest_key_for_vault(env_setup, nested_setup):
+def test_nest_key_for_vault(nested_setup, secret_setup):
     g = gestalt.Gestalt()
     g.add_config_file("./tests/testvault/testnested.json")
     g.configure_provider("vault", Vault(role=None, jwt=None))
@@ -612,37 +522,23 @@ def test_nest_key_for_vault(env_setup, nested_setup):
     assert secret_slack == "random-token"
 
 
-def test_read_no_nest_db_role(env_setup, mock_db_role_request):
+def test_read_no_nest_db_role(mock_db_role_request):
     g = gestalt.Gestalt()
     g.add_config_file("./tests/testvault/testsfdynamic.json")
     g.configure_provider("vault", Vault(role=None, jwt=None))
     g.build_config()
-    secret_username = g.get_string("snowflake.username")
+    secret_username = g.get_string("username")
     assert secret_username == "foo"
 
 
-def test_set_vault_key(env_setup, nested_setup):
+def test_set_vault_key(nested_setup):
     g = gestalt.Gestalt()
     g.configure_provider("vault", Vault(role=None, jwt=None))
     g.set_string(key="test",
                  value="ref+vault://secret/data/testnested#.slack.token")
     g.build_config()
     secret = g.get_string("test")
-    assert secret == "random-token"
-
-
-@pytest.fixture
-def mock_vault_workers():
-    mock_dynamic_renew = Mock()
-    mock_k8s_renew = Mock()
-    patch("gestalt.vault.Thread",
-          side_effect=[mock_dynamic_renew, mock_k8s_renew]).start()
-    return (mock_dynamic_renew, mock_k8s_renew)
-
-
-@pytest.fixture
-def mock_vault_k8s_auth():
-    return patch("gestalt.vault.hvac.api.auth_methods.Kubernetes").start()
+    assert secret == "ref+vault://secret/data/testnested#.slack.token"
 
 
 @pytest.mark.asyncio
@@ -743,3 +639,5 @@ async def test_vault_start_dynamic_lease(mock_vault_workers):
     mock_kube_token_queue.stop()
     mock_queues.stop()
     mock_vault_client_read.stop()
+
+

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -616,27 +616,28 @@ async def test_vault_start_dynamic_lease(mock_vault_workers):
             "data": "mock_data"
         }
     }
-    mock_vault_client_read = patch("gestalt.vault.hvac.Client.read",
-                                   return_value=mock_response).start()
 
-    mock_dynamic_token_queue = Mock()
-    mock_kube_token_queue = Mock()
-    mock_queues = patch(
-        "gestalt.vault.asyncio.Queue",
-        side_effect=[mock_dynamic_token_queue, mock_kube_token_queue]).start()
+    mock_vault_client_patch = patch("gestalt.vault.hvac.Client.read",
+                                    return_value=mock_response)
+    with mock_vault_client_patch as mock_vault_client_read:
+        mock_dynamic_token_queue = Mock()
+        mock_kube_token_queue = Mock()
+        mock_queues = patch(
+            "gestalt.vault.asyncio.Queue",
+            side_effect=[mock_dynamic_token_queue, mock_kube_token_queue]).start()
 
-    v = Vault(role=None, jwt=None)
-    g = gestalt.Gestalt()
-    g.add_config_file("./tests/testvault/testmount.json")
-    g.configure_provider("vault", v)
-    g.build_config()
-    g.get_string("test_mount")
+        v = Vault(role=None, jwt=None)
+        g = gestalt.Gestalt()
+        g.add_config_file("./tests/testvault/testmount.json")
+        g.configure_provider("vault", v)
+        g.build_config()
+        g.get_string("test_mount")
 
-    mock_vault_client_read.assert_called()
-    mock_dynamic_token_queue.put_nowait.assert_called()
+        mock_vault_client_read.assert_called()
+        mock_dynamic_token_queue.put_nowait.assert_called()
 
-    mock_vault_client_read.stop()
-    mock_dynamic_token_queue.stop()
-    mock_kube_token_queue.stop()
-    mock_queues.stop()
-    mock_vault_client_read.stop()
+        mock_vault_client_read.stop()
+        mock_dynamic_token_queue.stop()
+        mock_kube_token_queue.stop()
+        mock_queues.stop()
+        mock_vault_client_read.stop()

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -570,7 +570,6 @@ async def test_vault_worker_dynamic(mock_vault_workers, mock_vault_k8s_auth):
             mock_client().sys.renew_lease.assert_called()
             mock_k8s_renew.start.assert_called_once()
 
-            mock_vault_k8s_auth.stop()
             mock_dynamic_renew.stop()
             mock_k8s_renew.stop()
 
@@ -622,22 +621,23 @@ async def test_vault_start_dynamic_lease(mock_vault_workers):
     with mock_vault_client_patch as mock_vault_client_read:
         mock_dynamic_token_queue = Mock()
         mock_kube_token_queue = Mock()
-        mock_queues = patch(
-            "gestalt.vault.asyncio.Queue",
-            side_effect=[mock_dynamic_token_queue, mock_kube_token_queue]).start()
+        with patch(
+                "gestalt.vault.asyncio.Queue",
+                side_effect=[mock_dynamic_token_queue,
+                             mock_kube_token_queue]) as mock_queues:
 
-        v = Vault(role=None, jwt=None)
-        g = gestalt.Gestalt()
-        g.add_config_file("./tests/testvault/testmount.json")
-        g.configure_provider("vault", v)
-        g.build_config()
-        g.get_string("test_mount")
+            v = Vault(role=None, jwt=None)
+            g = gestalt.Gestalt()
+            g.add_config_file("./tests/testvault/testmount.json")
+            g.configure_provider("vault", v)
+            g.build_config()
+            g.get_string("test_mount")
 
-        mock_vault_client_read.assert_called()
-        mock_dynamic_token_queue.put_nowait.assert_called()
+            mock_vault_client_read.assert_called()
+            mock_dynamic_token_queue.put_nowait.assert_called()
 
-        mock_vault_client_read.stop()
-        mock_dynamic_token_queue.stop()
-        mock_kube_token_queue.stop()
-        mock_queues.stop()
-        mock_vault_client_read.stop()
+            mock_vault_client_read.stop()
+            mock_dynamic_token_queue.stop()
+            mock_kube_token_queue.stop()
+            mock_queues.stop()
+            mock_vault_client_read.stop()

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -1,545 +1,545 @@
-# # type: ignore
-#
-# from unittest.mock import patch, Mock
-#
-# from gestalt.vault import Vault
-# from gestalt import merge_into
-# import asyncio
-# import pytest
-# import os
-# import gestalt
-# import hvac
-#
-#
-# # Testing member function
-# def test_merge_into():
-#     combine1 = {}
-#     combine2 = {}
-#     combine3 = {"local": 1234, "pg": {"host": "dict1_pg", "pass": "dict1_pg"}}
-#     combine4 = {"local": 1234, "pg": {"host": "dict2_pg"}}
-#
-#     merge_into(combine3, combine1)
-#     merge_into(combine4, combine1)
-#
-#     merge_into(combine4, combine2)
-#     merge_into(combine3, combine2)
-#
-#     assert combine1 == {
-#         "local": 1234,
-#         "pg": {
-#             "host": "dict2_pg",
-#             "pass": "dict1_pg"
-#         }
-#     }
-#
-#     assert combine2 == {
-#         "local": 1234,
-#         "pg": {
-#             "host": "dict1_pg",
-#             "pass": "dict1_pg"
-#         }
-#     }
-#
-#
-# def test_combine_into_empty_dict():
-#     combine = {}
-#     merge_into({}, combine)
-#     assert combine == {}
-#
-#     combine = {"local": 1234}
-#     merge_into({}, combine)
-#     assert combine == {"local": 1234}
-#
-#
-# # Testing JSON Loading
-# def test_loading_json():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     x = g.dump()
-#     assert len(x)
-#
-#
-# def test_loading_json_file():
-#     g = gestalt.Gestalt()
-#     g.add_config_file('./tests/testdata/testjson.json')
-#     g.build_config()
-#     x = g.dump()
-#     assert len(x)
-#
-#
-# def test_loading_file_dir():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_file('./tests/testdata')
-#         assert 'is not a file' in terr
-#
-#
-# def test_loading_file_nonexist():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_file('./tests/testdata/nothere.yaml')
-#         g.build_config()
-#         assert 'is not a file' in terr
-#
-#
-# def test_loading_file_bad_yaml():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_file('./tests/testdatabad/testyaml.yaml')
-#         g.build_config()
-#         assert terr.type is ValueError
-#         assert 'but cannot be read as such' in terr.value.args[0]
-#
-#
-# def test_loading_file_bad_json():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_file('./tests/testdatabad/testjson.json')
-#         g.build_config()
-#         assert terr.type is ValueError
-#         assert 'but cannot be read as such' in terr.value.args[0]
-#
-#
-# def test_loading_dir_bad_files():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_path('./tests/testdatabad')
-#         g.build_config()
-#         assert terr.type is ValueError
-#         assert 'but cannot be read as such' in terr.value.args[0]
-#
-#
-# def test_loading_dir_bad_files_yaml_only():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_path('./tests/testdatabadyaml')
-#         g.build_config()
-#         assert terr.type is ValueError
-#         assert 'but cannot be read as such' in terr.value.args[0]
-#
-#
-# def test_loading_yaml_file():
-#     g = gestalt.Gestalt()
-#     g.add_config_file('./tests/testdata/testyaml.yaml')
-#     g.build_config()
-#     x = g.dump()
-#     assert len(x)
-#
-#
-# def test_loading_json_nonexist_dir():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_path('./nonexistpath')
-#         assert 'does not exist' in terr
-#
-#
-# def test_loading_json_file_not_dir():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(ValueError) as terr:
-#         g.add_config_path('./setup.py')
-#         assert 'is not a directory' in terr
-#
-#
-# def test_get_wrong_type():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     with pytest.raises(TypeError) as terr:
-#         g.get_string('numbers')
-#         assert 'is not of type' in terr
-#
-#
-# def test_get_non_exist_key():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     with pytest.raises(ValueError) as terr:
-#         g.get_string('non-exist')
-#         assert 'is not in any configuration and no default is provided' in terr
-#
-#
-# def test_get_key_wrong_type():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     with pytest.raises(TypeError) as terr:
-#         g.get_string(1234)
-#         assert 'is not of string type' in terr
-#
-#
-# def test_get_key_wrong_default_type():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     with pytest.raises(TypeError) as terr:
-#         g.get_string('nonexist', 1234)
-#         assert 'Provided default is of incorrect type' in terr
-#
-#
-# def test_get_json_string():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_string('yarn')
-#     assert testval == 'blue skies'
-#
-#
-# def test_get_json_default_string():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_string('nonexist', 'mydefval')
-#     assert testval == 'mydefval'
-#
-#
-# def test_get_json_set_default_string():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     g.set_default_string('nonexisttest', 'otherdefval')
-#     testval = g.get_string('nonexisttest')
-#     assert testval == 'otherdefval'
-#
-#
-# def test_get_json_int():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_int('numbers')
-#     assert testval == 12345678
-#
-#
-# def test_get_json_float():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_float('strangenumbers')
-#     assert testval == 123.456
-#
-#
-# def test_get_json_bool():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_bool('truthy')
-#     assert testval is True
-#
-#
-# def test_get_json_list():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_list('listing')
-#     assert testval
-#     assert 'dog' in testval
-#     assert 'cat' in testval
-#
-#
-# def test_get_json_nested():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_string('deep.nested1')
-#     assert testval == 'hello'
-#
-#
-# def test_get_yaml_nested():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_string('deep_yaml.nest1.nest2.foo')
-#     assert testval == 'hello'
-#
-#
-# # Test Set Overriding
-# def test_set_string():
-#     g = gestalt.Gestalt()
-#     g.set_string('mykey', 'myval')
-#     testval = g.get_string('mykey')
-#     assert testval == 'myval'
-#
-#
-# def test_set_int():
-#     g = gestalt.Gestalt()
-#     g.set_int('mykey', 1234)
-#     testval = g.get_int('mykey')
-#     assert testval == 1234
-#
-#
-# def test_set_float():
-#     g = gestalt.Gestalt()
-#     g.set_float('mykey', 45.23)
-#     testval = g.get_float('mykey')
-#     assert testval == 45.23
-#
-#
-# def test_set_bool():
-#     g = gestalt.Gestalt()
-#     g.set_bool('mykey', False)
-#     testval = g.get_bool('mykey')
-#     assert testval is False
-#
-#
-# def test_set_list():
-#     g = gestalt.Gestalt()
-#     g.set_list('mykey', ['hi', 'bye'])
-#     testval = g.get_list('mykey')
-#     assert testval
-#     assert 'hi' in testval
-#     assert 'bye' in testval
-#
-#
-# def test_set_int_get_bad():
-#     g = gestalt.Gestalt()
-#     g.set_int('mykey', 1234)
-#     with pytest.raises(TypeError) as terr:
-#         g.get_string('mykey')
-#         assert 'Given set key is not of type' in terr
-#
-#
-# def test_set_bad_key_type():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(TypeError) as terr:
-#         g.set_string(1234, 'myval')
-#         assert 'is not of string type' in terr
-#
-#
-# def test_set_bad_type():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(TypeError) as terr:
-#         g.set_string('mykey', 123)
-#         assert 'is not of type' in terr
-#
-#
-# def test_re_set_bad_type():
-#     g = gestalt.Gestalt()
-#     g.set_string('mykey', '123')
-#     with pytest.raises(TypeError) as terr:
-#         g.set_int('mykey', 123)
-#         assert 'Overriding key' in terr
-#
-#
-# def test_set_override():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     testval = g.get_int('numbers')
-#     assert testval == 12345678
-#     g.set_int('numbers', 6543)
-#     testval = g.get_int('numbers')
-#     assert testval == 6543
-#
-#
-# def test_set_bad_type_file_config():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     with pytest.raises(TypeError) as terr:
-#         g.set_string('numbers', 'notgood')
-#         assert 'File config has' in terr
-#
-#
-# def test_set_bad_type_default_config():
-#     g = gestalt.Gestalt()
-#     g.set_default_string('mykey', 'mystring')
-#     with pytest.raises(TypeError) as terr:
-#         g.set_int('mykey', 123)
-#         assert 'Default config has' in terr
-#
-#
-# # Test Env Variables
-# def test_get_env_string():
-#     g = gestalt.Gestalt()
-#     g.auto_env()
-#     os.environ['MYKEY'] = 'myval'
-#     testval = g.get_string('mykey')
-#     assert testval == 'myval'
-#
-#
-# def test_get_env_int():
-#     g = gestalt.Gestalt()
-#     g.auto_env()
-#     os.environ['MYKEY'] = '999'
-#     testval = g.get_int('mykey')
-#     assert testval == 999
-#
-#
-# def test_get_nested_env_string():
-#     g = gestalt.Gestalt()
-#     g.auto_env()
-#     os.environ['MY_KEY'] = 'myval'
-#     testval = g.get_string('my.key')
-#     assert testval == 'myval'
-#
-#
-# def test_get_env_bad_type():
-#     g = gestalt.Gestalt()
-#     g.auto_env()
-#     os.environ['MY_KEY'] = 'myval'
-#     with pytest.raises(TypeError) as terr:
-#         g.get_int('my.key')
-#         assert "could not be converted to type" in terr
-#
-#
-# # Test Default Values
-# def test_set_default_string():
-#     g = gestalt.Gestalt()
-#     g.set_default_string('mykey', 'myval')
-#     testval = g.get_string('mykey')
-#     assert testval == 'myval'
-#
-#
-# def test_set_default_int():
-#     g = gestalt.Gestalt()
-#     g.set_default_int('mykey', 1234)
-#     testval = g.get_int('mykey')
-#     assert testval == 1234
-#
-#
-# def test_set_default_float():
-#     g = gestalt.Gestalt()
-#     g.set_default_float('mykey', 1234.05)
-#     testval = g.get_float('mykey')
-#     assert testval == 1234.05
-#
-#
-# def test_set_default_bool():
-#     g = gestalt.Gestalt()
-#     g.set_default_bool('mykey', False)
-#     testval = g.get_bool('mykey')
-#     assert testval is False
-#
-#
-# def test_set_default_list():
-#     g = gestalt.Gestalt()
-#     g.set_default_list('mykey', ['bear', 'bull'])
-#     testval = g.get_list('mykey')
-#     assert testval
-#     assert 'bear' in testval
-#     assert 'bull' in testval
-#
-#
-# def test_set_default_int_get_bad():
-#     g = gestalt.Gestalt()
-#     g.set_default_int('mykey', 1234)
-#     with pytest.raises(TypeError) as terr:
-#         g.get_string('mykey')
-#         assert 'Given default set key is not of type' in terr
-#
-#
-# def test_set_default_string_bad_key():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(TypeError) as terr:
-#         g.set_default_string(1234, 'myval')
-#         assert 'Given key is not of string type' in terr
-#
-#
-# def test_set_default_string_bad_val():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(TypeError) as terr:
-#         g.set_default_string('mykey', 123)
-#         assert 'Input value when setting default' in terr
-#
-#
-# def test_set_default_string_bad_val_override():
-#     g = gestalt.Gestalt()
-#     with pytest.raises(TypeError) as terr:
-#         g.set_default_string('mykey', 'myval')
-#         g.set_default_int('mykey', 1234)
-#         assert 'Overriding default key' in terr
-#
-#
-# def test_override_nested_config():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testoverride/')
-#     g.build_config()
-#     assert g.get_int("local") == 123456
-#     assert g.get_string("nested1.nested2") == "final"
-#     assert g.get_string("pg.host") == "dev_host"
-#     assert g.get_string("pg.pass") == "def_pass"
-#     assert g.get_string("nested1.nested3.nested4.deeplevel") == "nested5"
-#
-#
-# def test_set_default_bad_type_file_config():
-#     g = gestalt.Gestalt()
-#     g.add_config_path('./tests/testdata')
-#     g.build_config()
-#     with pytest.raises(TypeError) as terr:
-#         g.set_default_string('numbers', 'notgood')
-#         assert 'File config has' in terr
-#
-#
-# def test_set_default_bad_type_set_config():
-#     g = gestalt.Gestalt()
-#     g.set_string('mykey', 'mystring')
-#     with pytest.raises(TypeError) as terr:
-#         g.set_default_int('mykey', 123)
-#         assert 'Set config has' in terr
-#
-#
-# def test_vault_setup():
-#     vault = Vault(role=None, jwt=None)
-#     assert vault.vault_client.is_authenticated() is True
-#
-#
-# def test_vault_interpolation(secret_setup):
-#     g = gestalt.Gestalt()
-#     g.add_config_file("./tests/testvault/testcorrect.json")
-#     vault = Vault(role=None, jwt=None)
-#     g.configure_provider("vault", vault)
-#     g.build_config()
-#     secret = g.get_string("test_secret.test_secret")
-#     assert secret == "test_secret_password"
-#
-#
-# def test_vault_mount_path(mount_setup):
-#     g = gestalt.Gestalt()
-#     g.add_config_file("./tests/testvault/testmount.json")
-#     g.configure_provider("vault", Vault(role=None, jwt=None))
-#     g.build_config()
-#     secret = g.get_string("test_mount.test_mount")
-#     assert secret == "test_mount_password"
-#
-#
-# def test_vault_incorrect_path(mount_setup):
-#     g = gestalt.Gestalt()
-#     g.add_config_file("./tests/testvault/testincorrectmount.json")
-#     g.configure_provider("vault", Vault(role=None, jwt=None))
-#     with pytest.raises(RuntimeError):
-#         g.build_config()
-#         g.get_string("test_mount")
-#
-#
-# def test_nest_key_for_vault(nested_setup, secret_setup):
-#     g = gestalt.Gestalt()
-#     g.add_config_file("./tests/testvault/testnested.json")
-#     g.configure_provider("vault", Vault(role=None, jwt=None))
-#     g.build_config()
-#     secret_db = g.get_string("remoteAPI.database.test_secret")
-#     secret_slack = g.get_string("remoteAPI.slack.token")
-#     assert secret_db == "test_secret_password"
-#     assert secret_slack == "random-token"
-#
-#
-# def test_read_no_nest_db_role(mock_db_role_request):
-#     g = gestalt.Gestalt()
-#     g.add_config_file("./tests/testvault/testsfdynamic.json")
-#     g.configure_provider("vault", Vault(role=None, jwt=None))
-#     g.build_config()
-#     secret_username = g.get_string("username")
-#     assert secret_username == "foo"
-#
-#
-# def test_set_vault_key(nested_setup):
-#     g = gestalt.Gestalt()
-#     g.configure_provider("vault", Vault(role=None, jwt=None))
-#     g.set_string(key="test",
-#                  value="ref+vault://secret/data/testnested#.slack.token")
-#     g.build_config()
-#     secret = g.get_string("test")
-#     assert secret == "ref+vault://secret/data/testnested#.slack.token"
-#
+# type: ignore
+
+from unittest.mock import patch, Mock
+
+from gestalt.vault import Vault
+from gestalt import merge_into
+import asyncio
+import pytest
+import os
+import gestalt
+import hvac
+
+
+# Testing member function
+def test_merge_into():
+    combine1 = {}
+    combine2 = {}
+    combine3 = {"local": 1234, "pg": {"host": "dict1_pg", "pass": "dict1_pg"}}
+    combine4 = {"local": 1234, "pg": {"host": "dict2_pg"}}
+
+    merge_into(combine3, combine1)
+    merge_into(combine4, combine1)
+
+    merge_into(combine4, combine2)
+    merge_into(combine3, combine2)
+
+    assert combine1 == {
+        "local": 1234,
+        "pg": {
+            "host": "dict2_pg",
+            "pass": "dict1_pg"
+        }
+    }
+
+    assert combine2 == {
+        "local": 1234,
+        "pg": {
+            "host": "dict1_pg",
+            "pass": "dict1_pg"
+        }
+    }
+
+
+def test_combine_into_empty_dict():
+    combine = {}
+    merge_into({}, combine)
+    assert combine == {}
+
+    combine = {"local": 1234}
+    merge_into({}, combine)
+    assert combine == {"local": 1234}
+
+
+# Testing JSON Loading
+def test_loading_json():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    x = g.dump()
+    assert len(x)
+
+
+def test_loading_json_file():
+    g = gestalt.Gestalt()
+    g.add_config_file('./tests/testdata/testjson.json')
+    g.build_config()
+    x = g.dump()
+    assert len(x)
+
+
+def test_loading_file_dir():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_file('./tests/testdata')
+        assert 'is not a file' in terr
+
+
+def test_loading_file_nonexist():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_file('./tests/testdata/nothere.yaml')
+        g.build_config()
+        assert 'is not a file' in terr
+
+
+def test_loading_file_bad_yaml():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_file('./tests/testdatabad/testyaml.yaml')
+        g.build_config()
+        assert terr.type is ValueError
+        assert 'but cannot be read as such' in terr.value.args[0]
+
+
+def test_loading_file_bad_json():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_file('./tests/testdatabad/testjson.json')
+        g.build_config()
+        assert terr.type is ValueError
+        assert 'but cannot be read as such' in terr.value.args[0]
+
+
+def test_loading_dir_bad_files():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_path('./tests/testdatabad')
+        g.build_config()
+        assert terr.type is ValueError
+        assert 'but cannot be read as such' in terr.value.args[0]
+
+
+def test_loading_dir_bad_files_yaml_only():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_path('./tests/testdatabadyaml')
+        g.build_config()
+        assert terr.type is ValueError
+        assert 'but cannot be read as such' in terr.value.args[0]
+
+
+def test_loading_yaml_file():
+    g = gestalt.Gestalt()
+    g.add_config_file('./tests/testdata/testyaml.yaml')
+    g.build_config()
+    x = g.dump()
+    assert len(x)
+
+
+def test_loading_json_nonexist_dir():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_path('./nonexistpath')
+        assert 'does not exist' in terr
+
+
+def test_loading_json_file_not_dir():
+    g = gestalt.Gestalt()
+    with pytest.raises(ValueError) as terr:
+        g.add_config_path('./setup.py')
+        assert 'is not a directory' in terr
+
+
+def test_get_wrong_type():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    with pytest.raises(TypeError) as terr:
+        g.get_string('numbers')
+        assert 'is not of type' in terr
+
+
+def test_get_non_exist_key():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    with pytest.raises(ValueError) as terr:
+        g.get_string('non-exist')
+        assert 'is not in any configuration and no default is provided' in terr
+
+
+def test_get_key_wrong_type():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    with pytest.raises(TypeError) as terr:
+        g.get_string(1234)
+        assert 'is not of string type' in terr
+
+
+def test_get_key_wrong_default_type():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    with pytest.raises(TypeError) as terr:
+        g.get_string('nonexist', 1234)
+        assert 'Provided default is of incorrect type' in terr
+
+
+def test_get_json_string():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_string('yarn')
+    assert testval == 'blue skies'
+
+
+def test_get_json_default_string():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_string('nonexist', 'mydefval')
+    assert testval == 'mydefval'
+
+
+def test_get_json_set_default_string():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    g.set_default_string('nonexisttest', 'otherdefval')
+    testval = g.get_string('nonexisttest')
+    assert testval == 'otherdefval'
+
+
+def test_get_json_int():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_int('numbers')
+    assert testval == 12345678
+
+
+def test_get_json_float():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_float('strangenumbers')
+    assert testval == 123.456
+
+
+def test_get_json_bool():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_bool('truthy')
+    assert testval is True
+
+
+def test_get_json_list():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_list('listing')
+    assert testval
+    assert 'dog' in testval
+    assert 'cat' in testval
+
+
+def test_get_json_nested():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_string('deep.nested1')
+    assert testval == 'hello'
+
+
+def test_get_yaml_nested():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_string('deep_yaml.nest1.nest2.foo')
+    assert testval == 'hello'
+
+
+# Test Set Overriding
+def test_set_string():
+    g = gestalt.Gestalt()
+    g.set_string('mykey', 'myval')
+    testval = g.get_string('mykey')
+    assert testval == 'myval'
+
+
+def test_set_int():
+    g = gestalt.Gestalt()
+    g.set_int('mykey', 1234)
+    testval = g.get_int('mykey')
+    assert testval == 1234
+
+
+def test_set_float():
+    g = gestalt.Gestalt()
+    g.set_float('mykey', 45.23)
+    testval = g.get_float('mykey')
+    assert testval == 45.23
+
+
+def test_set_bool():
+    g = gestalt.Gestalt()
+    g.set_bool('mykey', False)
+    testval = g.get_bool('mykey')
+    assert testval is False
+
+
+def test_set_list():
+    g = gestalt.Gestalt()
+    g.set_list('mykey', ['hi', 'bye'])
+    testval = g.get_list('mykey')
+    assert testval
+    assert 'hi' in testval
+    assert 'bye' in testval
+
+
+def test_set_int_get_bad():
+    g = gestalt.Gestalt()
+    g.set_int('mykey', 1234)
+    with pytest.raises(TypeError) as terr:
+        g.get_string('mykey')
+        assert 'Given set key is not of type' in terr
+
+
+def test_set_bad_key_type():
+    g = gestalt.Gestalt()
+    with pytest.raises(TypeError) as terr:
+        g.set_string(1234, 'myval')
+        assert 'is not of string type' in terr
+
+
+def test_set_bad_type():
+    g = gestalt.Gestalt()
+    with pytest.raises(TypeError) as terr:
+        g.set_string('mykey', 123)
+        assert 'is not of type' in terr
+
+
+def test_re_set_bad_type():
+    g = gestalt.Gestalt()
+    g.set_string('mykey', '123')
+    with pytest.raises(TypeError) as terr:
+        g.set_int('mykey', 123)
+        assert 'Overriding key' in terr
+
+
+def test_set_override():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    testval = g.get_int('numbers')
+    assert testval == 12345678
+    g.set_int('numbers', 6543)
+    testval = g.get_int('numbers')
+    assert testval == 6543
+
+
+def test_set_bad_type_file_config():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    with pytest.raises(TypeError) as terr:
+        g.set_string('numbers', 'notgood')
+        assert 'File config has' in terr
+
+
+def test_set_bad_type_default_config():
+    g = gestalt.Gestalt()
+    g.set_default_string('mykey', 'mystring')
+    with pytest.raises(TypeError) as terr:
+        g.set_int('mykey', 123)
+        assert 'Default config has' in terr
+
+
+# Test Env Variables
+def test_get_env_string():
+    g = gestalt.Gestalt()
+    g.auto_env()
+    os.environ['MYKEY'] = 'myval'
+    testval = g.get_string('mykey')
+    assert testval == 'myval'
+
+
+def test_get_env_int():
+    g = gestalt.Gestalt()
+    g.auto_env()
+    os.environ['MYKEY'] = '999'
+    testval = g.get_int('mykey')
+    assert testval == 999
+
+
+def test_get_nested_env_string():
+    g = gestalt.Gestalt()
+    g.auto_env()
+    os.environ['MY_KEY'] = 'myval'
+    testval = g.get_string('my.key')
+    assert testval == 'myval'
+
+
+def test_get_env_bad_type():
+    g = gestalt.Gestalt()
+    g.auto_env()
+    os.environ['MY_KEY'] = 'myval'
+    with pytest.raises(TypeError) as terr:
+        g.get_int('my.key')
+        assert "could not be converted to type" in terr
+
+
+# Test Default Values
+def test_set_default_string():
+    g = gestalt.Gestalt()
+    g.set_default_string('mykey', 'myval')
+    testval = g.get_string('mykey')
+    assert testval == 'myval'
+
+
+def test_set_default_int():
+    g = gestalt.Gestalt()
+    g.set_default_int('mykey', 1234)
+    testval = g.get_int('mykey')
+    assert testval == 1234
+
+
+def test_set_default_float():
+    g = gestalt.Gestalt()
+    g.set_default_float('mykey', 1234.05)
+    testval = g.get_float('mykey')
+    assert testval == 1234.05
+
+
+def test_set_default_bool():
+    g = gestalt.Gestalt()
+    g.set_default_bool('mykey', False)
+    testval = g.get_bool('mykey')
+    assert testval is False
+
+
+def test_set_default_list():
+    g = gestalt.Gestalt()
+    g.set_default_list('mykey', ['bear', 'bull'])
+    testval = g.get_list('mykey')
+    assert testval
+    assert 'bear' in testval
+    assert 'bull' in testval
+
+
+def test_set_default_int_get_bad():
+    g = gestalt.Gestalt()
+    g.set_default_int('mykey', 1234)
+    with pytest.raises(TypeError) as terr:
+        g.get_string('mykey')
+        assert 'Given default set key is not of type' in terr
+
+
+def test_set_default_string_bad_key():
+    g = gestalt.Gestalt()
+    with pytest.raises(TypeError) as terr:
+        g.set_default_string(1234, 'myval')
+        assert 'Given key is not of string type' in terr
+
+
+def test_set_default_string_bad_val():
+    g = gestalt.Gestalt()
+    with pytest.raises(TypeError) as terr:
+        g.set_default_string('mykey', 123)
+        assert 'Input value when setting default' in terr
+
+
+def test_set_default_string_bad_val_override():
+    g = gestalt.Gestalt()
+    with pytest.raises(TypeError) as terr:
+        g.set_default_string('mykey', 'myval')
+        g.set_default_int('mykey', 1234)
+        assert 'Overriding default key' in terr
+
+
+def test_override_nested_config():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testoverride/')
+    g.build_config()
+    assert g.get_int("local") == 123456
+    assert g.get_string("nested1.nested2") == "final"
+    assert g.get_string("pg.host") == "dev_host"
+    assert g.get_string("pg.pass") == "def_pass"
+    assert g.get_string("nested1.nested3.nested4.deeplevel") == "nested5"
+
+
+def test_set_default_bad_type_file_config():
+    g = gestalt.Gestalt()
+    g.add_config_path('./tests/testdata')
+    g.build_config()
+    with pytest.raises(TypeError) as terr:
+        g.set_default_string('numbers', 'notgood')
+        assert 'File config has' in terr
+
+
+def test_set_default_bad_type_set_config():
+    g = gestalt.Gestalt()
+    g.set_string('mykey', 'mystring')
+    with pytest.raises(TypeError) as terr:
+        g.set_default_int('mykey', 123)
+        assert 'Set config has' in terr
+
+
+def test_vault_setup():
+    vault = Vault(role=None, jwt=None)
+    assert vault.vault_client.is_authenticated() is True
+
+
+def test_vault_interpolation(secret_setup):
+    g = gestalt.Gestalt()
+    g.add_config_file("./tests/testvault/testcorrect.json")
+    vault = Vault(role=None, jwt=None)
+    g.configure_provider("vault", vault)
+    g.build_config()
+    secret = g.get_string("test_secret.test_secret")
+    assert secret == "test_secret_password"
+
+
+def test_vault_mount_path(mount_setup):
+    g = gestalt.Gestalt()
+    g.add_config_file("./tests/testvault/testmount.json")
+    g.configure_provider("vault", Vault(role=None, jwt=None))
+    g.build_config()
+    secret = g.get_string("test_mount.test_mount")
+    assert secret == "test_mount_password"
+
+
+def test_vault_incorrect_path(mount_setup):
+    g = gestalt.Gestalt()
+    g.add_config_file("./tests/testvault/testincorrectmount.json")
+    g.configure_provider("vault", Vault(role=None, jwt=None))
+    with pytest.raises(RuntimeError):
+        g.build_config()
+        g.get_string("test_mount")
+
+
+def test_nest_key_for_vault(nested_setup, secret_setup):
+    g = gestalt.Gestalt()
+    g.add_config_file("./tests/testvault/testnested.json")
+    g.configure_provider("vault", Vault(role=None, jwt=None))
+    g.build_config()
+    secret_db = g.get_string("remoteAPI.database.test_secret")
+    secret_slack = g.get_string("remoteAPI.slack.token")
+    assert secret_db == "test_secret_password"
+    assert secret_slack == "random-token"
+
+
+def test_read_no_nest_db_role(mock_db_role_request):
+    g = gestalt.Gestalt()
+    g.add_config_file("./tests/testvault/testsfdynamic.json")
+    g.configure_provider("vault", Vault(role=None, jwt=None))
+    g.build_config()
+    secret_username = g.get_string("username")
+    assert secret_username == "foo"
+
+
+def test_set_vault_key(nested_setup):
+    g = gestalt.Gestalt()
+    g.configure_provider("vault", Vault(role=None, jwt=None))
+    g.set_string(key="test",
+                 value="ref+vault://secret/data/testnested#.slack.token")
+    g.build_config()
+    secret = g.get_string("test")
+    assert secret == "ref+vault://secret/data/testnested#.slack.token"
+
 #
 # @pytest.mark.asyncio
 # async def test_vault_worker_dynamic(mock_vault_workers, mock_vault_k8s_auth):
@@ -640,5 +640,5 @@
 #     mock_kube_token_queue.stop()
 #     mock_queues.stop()
 #     mock_vault_client_read.stop()
-#
-#
+
+

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,29 @@
+# type: ignore
+
+from gestalt.vault import Vault
+import datetime
+
+
+def test_get(mount_setup):
+    mount_setup_path = "test-mount/data/test"
+    key = "test_mount"
+    filter_ = f".{key}"
+    expected = "test_mount_password"
+    vault = Vault()
+    result = vault.get(key=key, path=mount_setup_path, filter=filter_)
+    assert result == expected
+
+
+def test_get_cache_hit(mock_db_role_request):
+    mount_setup_path = "test-mount/data/test"
+    key = "password"
+    filter_ = f".{key}"
+    expected = "foo"
+    expected_expiry_time = datetime.datetime(2023, 5, 31, 14, 24, 41)
+    vault = Vault()
+    result_one = vault.get(key=key, path=mount_setup_path, filter=filter_)
+    result_two = vault.get(key=key, path=mount_setup_path, filter=filter_)
+    assert result_one == expected and result_two == expected
+    assert vault._secret_expiry_times[key] == expected_expiry_time
+    assert vault._secret_values[key] == expected
+

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -26,4 +26,3 @@ def test_get_cache_hit(mock_db_role_request):
     assert result_one == expected and result_two == expected
     assert vault._secret_expiry_times[key] == expected_expiry_time
     assert vault._secret_values[key] == expected
-

--- a/tests/testvault/testsfdynamic.json
+++ b/tests/testvault/testsfdynamic.json
@@ -1,3 +1,3 @@
 {
-    "snowflake": "ref+vault://database/creds/my-role#"
+    "username": "ref+vault://database/creds/my-role#.username"
 }


### PR DESCRIPTION
* Adds vault response caching in vault provider `vault.py` -- for supporting vault responses with a TTL (i.e. Snowflake password rotation). This is done via keeping an internal dictionary where keys are the vault key and values are time to expiry.

* Gestalt no longer writes the interpolated value of the provider key. It instead keeps the value as is (`ref+vault://`) and if a key in the underlying `gestalt` dict starts with the Vault provider scheme, it will dispatch the request to the `.get` vault provider method (which could be cached).

* Moves pytest fixtures into a dedicated `conftest.py` module.