### PR TITLE
bump pyyaml to 6.0.1

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,7 +7,7 @@ pytest-cov==2.8.1
 pytest-mock==3.2.0
 hvac>=1.0.2,<1.1.0
 types-requests==2.25.2
-types-PyYAML==5.4.6
+types-PyYAML==6.0.12.11
 retry==0.9.2
 types-retry==0.9.9
 jsonpath-ng==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==5.4.1
+PyYAML==6.0.1
 hvac>=1.0.2,<1.1.0
 jsonpath-ng==1.5.3
 retry==0.9.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,6 @@ python_files = tests/*.py
 
 [options]
 install_requires =
-    PyYAML==5.4.1
+    PyYAML==6.0.1
     hvac>=0.11.2,<0.12.0
     jsonpath-ng==1.5.3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.3.1',
+      version='3.3.2',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
pyyaml 5.4.1 broke with cython 3. 6.0.1 forces it to use < cython 3.0