### PR TITLE
fix vault work memory leak

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.3.2',
+      version='3.3.3',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
The thread that gestalt creates for vault token renewal isn't properly GC'd, leading to memory issues if a consumer creates multiple instances of config.

Add flag to stop worker loop in __del__ which is called right before GC.
