### PR TITLE
Allows runtime configuration of vault provider retry delay and tries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## Unreleased
+
+## [3.3.6] - 2023-06-11
+
+### Changes
+- Removed `retry` decorator usage in `vault.py`
+- Invokes `vault_client` calls through `retry_call` instead
+- Adds`delay` and `tries` to `Vault` constructor for runtime configuration of `retry_call`
+- Sets `delay` default to 60 seconds and `tries` to 5
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
-
+***
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
-
+***
 ## [3.3.6] - 2023-06-11
 
 ### Added
@@ -17,5 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Invokes `vault_client` calls through `retry_call` instead
 
 
+## Released
+***
 
+# TODO
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [3.3.6] - 2023-06-11
 
-### Changes
+### Added
+- `delay` and `tries` to `Vault` constructor for runtime configuration of `retry_call`
+- `delay` default to 60 seconds and `tries` to 5
+
+### Changed
 - Removed `retry` decorator usage in `vault.py`
 - Invokes `vault_client` calls through `retry_call` instead
-- Adds`delay` and `tries` to `Vault` constructor for runtime configuration of `retry_call`
-- Sets `delay` default to 60 seconds and `tries` to 5
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ***
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Unreleased
 ***

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -82,8 +82,8 @@ class Vault(Provider):
                     kubes_token = (
                         "kubernetes",
                         token["data"]["id"],  # type: ignore
-                        token["data"]["ttl"],
-                    )  # type: ignore
+                        token["data"]["ttl"],  # type: ignore
+                    )
                     self.kubes_token_queue.put(kubes_token)
             except hvac.exceptions.InvalidPath:
                 raise RuntimeError(

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -15,7 +15,6 @@ from gestalt.provider import Provider
 
 
 class Vault(Provider):
-
     def __init__(
         self,
         cert: Optional[Tuple[str, str]] = None,
@@ -41,14 +40,14 @@ class Vault(Provider):
 
     # __init__ impl for retry_call
     def __do_init(
-        self,
-        cert: Optional[Tuple[str, str]],
-        role: Optional[str],
-        jwt: Optional[str],
-        url: Optional[str],
-        token: Optional[str],
-        verify: Optional[bool],
-        scheme: str,
+            self,
+            cert: Optional[Tuple[str, str]],
+            role: Optional[str],
+            jwt: Optional[str],
+            url: Optional[str],
+            token: Optional[str],
+            verify: Optional[bool],
+            scheme: str,
     ) -> None:
         """Initialized vault client and authenticates vault
         Args:
@@ -116,12 +115,13 @@ class Vault(Provider):
     def __del__(self) -> None:
         self.stop()
 
-    def get(self,
-            key: str,
-            path: str,
-            filter: str,
-            sep: Optional[str] = "."
-            ) -> Union[str, int, float, bool, List[Any]]:
+    def get(
+        self,
+        key: str,
+        path: str,
+        filter: str,
+        sep: Optional[str] = "."
+    ) -> Union[str, int, float, bool, List[Any]]:
         return retry_call(
             f=Vault.__do_get,
             fargs=[self, key, path, filter, sep],
@@ -130,12 +130,13 @@ class Vault(Provider):
             tries=self.tries,
         )
 
-    def __do_get(self,
-                 key: str,
-                 path: str,
-                 filter: str,
-                 sep: Optional[str] = "."
-                 ) -> Union[str, int, float, bool, List[Any]]:
+    def __do_get(
+        self,
+        key: str,
+        path: str,
+        filter: str,
+        sep: Optional[str] = "."
+    ) -> Union[str, int, float, bool, List[Any]]:
         """Gets secret from vault
         Args:
             key (str): key to get secret from

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -15,6 +15,7 @@ from gestalt.provider import Provider
 
 
 class Vault(Provider):
+
     def __init__(
         self,
         cert: Optional[Tuple[str, str]] = None,
@@ -61,9 +62,13 @@ class Vault(Provider):
         self.dynamic_token_queue: Queue[Tuple[str, str, str]] = Queue()
         self.kubes_token_queue: Queue[Tuple[str, str, str]] = Queue()
 
-        self.vault_client = hvac.Client(url=url, token=token, cert=cert, verify=verify)
+        self.vault_client = hvac.Client(url=url,
+                                        token=token,
+                                        cert=cert,
+                                        verify=verify)
         self._secret_expiry_times: Dict[str, datetime] = dict()
-        self._secret_values: Dict[str, Union[str, int, float, bool, List[Any]]] = dict()
+        self._secret_values: Dict[str, Union[str, int, float, bool,
+                                             List[Any]]] = dict()
 
         try:
             self.vault_client.is_authenticated()
@@ -74,9 +79,8 @@ class Vault(Provider):
 
         if role and jwt:
             try:
-                hvac.api.auth_methods.Kubernetes(self.vault_client.adapter).login(
-                    role=role, jwt=jwt
-                )
+                hvac.api.auth_methods.Kubernetes(
+                    self.vault_client.adapter).login(role=role, jwt=jwt)
                 token = self.vault_client.auth.token.lookup_self()
                 if token is not None:
                     kubes_token = (
@@ -87,8 +91,7 @@ class Vault(Provider):
                     self.kubes_token_queue.put(kubes_token)
             except hvac.exceptions.InvalidPath:
                 raise RuntimeError(
-                    "Gestalt Error: Kubernetes auth couldn't be performed"
-                )
+                    "Gestalt Error: Kubernetes auth couldn't be performed")
             except requests.exceptions.ConnectionError:
                 raise RuntimeError("Gestalt Error: Couldn't connect to Vault")
 
@@ -96,13 +99,13 @@ class Vault(Provider):
                 name="dynamic-token-renew",
                 target=self.worker,
                 daemon=True,
-                args=(self.dynamic_token_queue,),
+                args=(self.dynamic_token_queue, ),
             )  # noqa: F841
             kubernetes_ttl_renew = Thread(
                 name="kubes-token-renew",
                 target=self.worker,
                 daemon=True,
-                args=(self.kubes_token_queue,),
+                args=(self.kubes_token_queue, ),
             )
             kubernetes_ttl_renew.start()
 
@@ -112,9 +115,12 @@ class Vault(Provider):
     def __del__(self) -> None:
         self.stop()
 
-    def get(
-        self, key: str, path: str, filter: str, sep: Optional[str] = "."
-    ) -> Union[str, int, float, bool, List[Any]]:
+    def get(self,
+            key: str,
+            path: str,
+            filter: str,
+            sep: Optional[str] = "."
+            ) -> Union[str, int, float, bool, List[Any]]:
         return retry_call(
             f=Vault.__do_get,
             fargs=[self, key, path, filter, sep],
@@ -123,9 +129,12 @@ class Vault(Provider):
             tries=self.tries,
         )
 
-    def __do_get(
-        self, key: str, path: str, filter: str, sep: Optional[str] = "."
-    ) -> Union[str, int, float, bool, List[Any]]:
+    def __do_get(self,
+                 key: str,
+                 path: str,
+                 filter: str,
+                 sep: Optional[str] = "."
+                 ) -> Union[str, int, float, bool, List[Any]]:
         """Gets secret from vault
         Args:
             key (str): key to get secret from
@@ -140,7 +149,8 @@ class Vault(Provider):
             return self._secret_values[key]
 
         # if the secret can expire but hasn't expired yet
-        if key in self._secret_expiry_times and not self._is_secret_expired(key):
+        if key in self._secret_expiry_times and not self._is_secret_expired(
+                key):
             return self._secret_values[key]
 
         try:
@@ -157,10 +167,10 @@ class Vault(Provider):
             requested_data = response["data"].get("data", response["data"])
         except hvac.exceptions.InvalidPath:
             raise RuntimeError(
-                "Gestalt Error: The secret path or mount is set incorrectly"
-            )
+                "Gestalt Error: The secret path or mount is set incorrectly")
         except requests.exceptions.ConnectionError:
-            raise RuntimeError("Gestalt Error: Gestalt couldn't connect to Vault")
+            raise RuntimeError(
+                "Gestalt Error: Gestalt couldn't connect to Vault")
         except Exception as err:
             raise RuntimeError(f"Gestalt Error: {err}")
         if filter is None:
@@ -186,13 +196,12 @@ class Vault(Provider):
         is_expired = now >= secret_expires_dt
         return is_expired
 
-    def _set_secrets_ttl(self, requested_data: Dict[str, Any], key: str) -> None:
-        last_vault_rotation_str = requested_data["last_vault_rotation"].split(".")[
-            0
-        ]  # to the nearest second
-        last_vault_rotation_dt = datetime.strptime(
-            last_vault_rotation_str, "%Y-%m-%dT%H:%M:%S"
-        )
+    def _set_secrets_ttl(self, requested_data: Dict[str, Any],
+                         key: str) -> None:
+        last_vault_rotation_str = requested_data["last_vault_rotation"].split(
+            ".")[0]  # to the nearest second
+        last_vault_rotation_dt = datetime.strptime(last_vault_rotation_str,
+                                                   "%Y-%m-%dT%H:%M:%S")
         ttl = requested_data["ttl"]
         secret_expires_dt = last_vault_rotation_dt + timedelta(seconds=ttl)
         self._secret_expiry_times[key] = secret_expires_dt
@@ -205,7 +214,8 @@ class Vault(Provider):
         try:
             while self._run_worker:
                 if not token_queue.empty():
-                    token_type, token_id, token_duration = token = token_queue.get()
+                    token_type, token_id, token_duration = token = token_queue.get(
+                    )
                     if token_type == "kubernetes":
                         self.vault_client.auth.token.renew(token_id)
                         print("kubernetes token for the app has been renewed")
@@ -217,10 +227,10 @@ class Vault(Provider):
                     sleep((token_duration / 3) * 2)
         except hvac.exceptions.InvalidPath:
             raise RuntimeError(
-                "Gestalt Error: The lease path or mount is set incorrectly"
-            )
+                "Gestalt Error: The lease path or mount is set incorrectly")
         except requests.exceptions.ConnectionError:
-            raise RuntimeError("Gestalt Error: Gestalt couldn't connect to Vault")
+            raise RuntimeError(
+                "Gestalt Error: Gestalt couldn't connect to Vault")
         except Exception as err:
             raise RuntimeError(f"Gestalt Error: {err}")
 

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -24,8 +24,8 @@ class Vault(Provider):
                  token: Optional[str] = os.environ.get("VAULT_TOKEN"),
                  verify: Optional[bool] = True,
                  scheme: str = "ref+vault://",
-                 delay=2,
-                 tries=5) -> None:
+                 delay: int = 2,
+                 tries: int = 5) -> None:
 
         self.delay = delay
         self.tries = tries

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -130,6 +130,7 @@ class Vault(Provider):
             tries=self.tries,
         )
 
+    # get impl for retry_call
     def __do_get(
         self,
         key: str,

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -1,15 +1,17 @@
-from datetime import datetime, timedelta
-from time import sleep
-from gestalt.provider import Provider
-import requests
-from requests.exceptions import Timeout
-from jsonpath_ng import parse  # type: ignore
-from typing import Optional, Tuple, Any, Dict, Union, List
-import hvac  # type: ignore
-from queue import Queue
 import os
+from datetime import datetime, timedelta
+from queue import Queue
 from threading import Thread
+from time import sleep
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import hvac  # type: ignore
+import requests
+from jsonpath_ng import parse  # type: ignore
+from requests.exceptions import Timeout
 from retry.api import retry_call
+
+from gestalt.provider import Provider
 
 
 class Vault(Provider):
@@ -28,7 +30,7 @@ class Vault(Provider):
         self.delay = delay
         self.tries = tries
 
-        retry_call(f=Vault.__do_init, fargs=[self, cert, role, jwt, url, token, verify],
+        retry_call(f=Vault.__do_init, fargs=[self, cert, role, jwt, url, token, verify, scheme],
                    exceptions=(RuntimeError, Timeout), delay=self.delay,
                    tries=self.tries)
 
@@ -102,13 +104,13 @@ class Vault(Provider):
     def __del__(self) -> None:
         self.stop()
 
-        def get(
-                self,
-                key: str,
-                path: str,
-                filter: str,
-                sep: Optional[str] = "."
-        ) -> Union[str, int, float, bool, List[Any]]:
+    def get(
+            self,
+            key: str,
+            path: str,
+            filter: str,
+            sep: Optional[str] = "."
+    ) -> Union[str, int, float, bool, List[Any]]:
 
         return retry_call(f=Vault.__do_get, fargs=[self, key, path, filter, sep], exceptions=(RuntimeError, Timeout),
                           delay=self.delay, tries=self.tries)

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -28,6 +28,7 @@ class Vault(Provider):
         tries: int = 5,
     ) -> None:
         """Initialized vault client and authenticates vault
+
         Args:
             client_config (HVAC_ClientConfig): initializes vault. URL can be set in VAULT_ADDR
                 environment variable, token can be set to VAULT_TOKEN environment variable.
@@ -77,9 +78,8 @@ class Vault(Provider):
                 if token is not None:
                     kubes_token = (
                         "kubernetes",
-                        token["data"]["id"],  # type: ignore
-                        token["data"]["ttl"],  # type: ignore
-                    )
+                        token['data']['id'],  # type: ignore
+                        token['data']['ttl'])  # type: ignore
                     self.kubes_token_queue.put(kubes_token)
             except hvac.exceptions.InvalidPath:
                 raise RuntimeError(
@@ -88,17 +88,14 @@ class Vault(Provider):
                 raise RuntimeError("Gestalt Error: Couldn't connect to Vault")
 
             dynamic_ttl_renew = Thread(
-                name="dynamic-token-renew",
+                name='dynamic-token-renew',
                 target=self.worker,
                 daemon=True,
-                args=(self.dynamic_token_queue, ),
-            )  # noqa: F841
-            kubernetes_ttl_renew = Thread(
-                name="kubes-token-renew",
-                target=self.worker,
-                daemon=True,
-                args=(self.kubes_token_queue, ),
-            )
+                args=(self.dynamic_token_queue, ))  # noqa: F841
+            kubernetes_ttl_renew = Thread(name="kubes-token-renew",
+                                          target=self.worker,
+                                          daemon=True,
+                                          args=(self.kubes_token_queue, ))
             kubernetes_ttl_renew.start()
 
     def stop(self) -> None:
@@ -142,12 +139,9 @@ class Vault(Provider):
             )
             if response is None:
                 raise RuntimeError("Gestalt Error: No secrets found")
-            if response["lease_id"]:
-                dynamic_token = (
-                    "dynamic",
-                    response["lease_id"],
-                    response["lease_duration"],
-                )
+            if response['lease_id']:
+                dynamic_token = ("dynamic", response['lease_id'],
+                                 response['lease_duration'])
                 self.dynamic_token_queue.put_nowait(dynamic_token)
             requested_data = response["data"].get("data", response["data"])
         except hvac.exceptions.InvalidPath:
@@ -186,7 +180,7 @@ class Vault(Provider):
         last_vault_rotation_str = requested_data["last_vault_rotation"].split(
             ".")[0]  # to the nearest second
         last_vault_rotation_dt = datetime.strptime(last_vault_rotation_str,
-                                                   "%Y-%m-%dT%H:%M:%S")
+                                                   '%Y-%m-%dT%H:%M:%S')
         ttl = requested_data["ttl"]
         secret_expires_dt = last_vault_rotation_dt + timedelta(seconds=ttl)
         self._secret_expiry_times[key] = secret_expires_dt

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -39,6 +39,7 @@ class Vault(Provider):
             tries=self.tries,
         )
 
+    # __init__ impl for retry_call
     def __do_init(
         self,
         cert: Optional[Tuple[str, str]],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as reqs_file:
     reqs_list = list(map(lambda x: x.rstrip(), reqs))
 
 setup(name='gestalt-cfg',
-      version='3.3.5',
+      version='3.3.6',
       description='A sensible configuration library for Python',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Due to recent issues on sync jobs caused by the Vault connectivity issues that are leading to timeouts, the ability to extend the timeout is desired. The existing implementation does not allow this at runtime due its use of decorators. This PR uses the retry_api.retry_call to facilitate runtime specification of delay and tries for retry.