### PR TITLE
Return raw secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## [3.4.1] - 2024-07-12
+
+### Fixed
+- Returning Raw string instead of parsing. This fixes the case where secret has \\$ in - Python would return \$ - therefore we are calling repr 
 
 ## [3.4.0] - 2024-03-04
 

--- a/gestalt/vault.py
+++ b/gestalt/vault.py
@@ -192,7 +192,10 @@ class Vault(Provider):
         if "ttl" in requested_data:
             self._set_secrets_ttl(requested_data, key)
 
-        return returned_value_from_secret  # type: ignore
+        # repr is converting the string to RAW string since \\$ was returning $\
+        # Then we are removing single quotes (first and last char)
+        #
+        return str(repr(returned_value_from_secret))[1:-1]
 
     def _is_secret_expired(self, key: str) -> bool:
         now = datetime.now()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt") as reqs_file:
 
 setup(
     name="gestalt-cfg",
-    version="3.4.0",
+    version="3.4.1",
     description="A sensible configuration library for Python",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,20 +8,20 @@ import requests
 class MockSession(requests.Session):
     def request(self, *_, **__):
         resp = {
-            'request_id': '230f5e67-e55d-bdae-bd24-c7bc13c1a3e9',
-            'lease_id': '',
-            'renewable': False,
-            'lease_duration': 0,
-            'data': {
-                'last_vault_rotation': '2023-05-31T14:24:41.724285249Z',
-                'password': 'foo',
-                'rotation_period': 60,
-                'ttl': 0,
-                'username': 'foo'
+            "request_id": "230f5e67-e55d-bdae-bd24-c7bc13c1a3e9",
+            "lease_id": "",
+            "renewable": False,
+            "lease_duration": 0,
+            "data": {
+                "last_vault_rotation": "2023-05-31T14:24:41.724285249Z",
+                "password": "foo",
+                "rotation_period": 60,
+                "ttl": 0,
+                "username": "foo",
             },
-            'wrap_info': None,
-            'warnings': None,
-            'auth': None
+            "wrap_info": None,
+            "warnings": None,
+            "auth": None,
         }
         return MockResponse(resp, 200)
 
@@ -50,21 +50,22 @@ def secret_setup():
 
 @pytest.fixture(scope="function")
 def incorrect_env_setup():
-    os.environ['VAULT_ADDR'] = ""
+    os.environ["VAULT_ADDR"] = ""
 
 
 @pytest.fixture(scope="function")
 def mount_setup():
     client = hvac.Client()
     secret_engines_list = client.sys.list_mounted_secrets_engines(
-    )['data'].keys()
+    )["data"].keys()
     if "test-mount/" in secret_engines_list:
         client.sys.disable_secrets_engine(path="test-mount")
     client.sys.enable_secrets_engine(backend_type="kv", path="test-mount")
     client.secrets.kv.v2.create_or_update_secret(
         mount_point="test-mount",
         path="test",
-        secret=dict(test_mount="test_mount_password"))
+        secret=dict(test_mount="test_mount_password\\$"),
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_gestalt.py
+++ b/tests/test_gestalt.py
@@ -256,7 +256,7 @@ def test_get_yaml_nested_default():
     g = gestalt.Gestalt()
     g.add_config_path("./tests/testdata")
     g.build_config()
-    testval = g.get_string("deep_yaml.nest1.nest2.foo", 'default')
+    testval = g.get_string("deep_yaml.nest1.nest2.foo", "default")
     assert testval == "hello"
 
 
@@ -264,7 +264,7 @@ def test_get_yaml_missing_nested_default():
     g = gestalt.Gestalt()
     g.add_config_path("./tests/testdata")
     g.build_config()
-    testval = g.get_string("deep_yaml.nest1.nest2.fob", 'default')
+    testval = g.get_string("deep_yaml.nest1.nest2.fob", "default")
     assert testval == "default"
 
 
@@ -515,7 +515,7 @@ def test_vault_mount_path(mount_setup):
     g.configure_provider("vault", Vault(role=None, jwt=None))
     g.build_config()
     secret = g.get_string("test_mount.test_mount")
-    assert secret == "test_mount_password"
+    assert secret == r"test_mount_password\\$"
 
 
 def test_vault_incorrect_path(mount_setup):

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -8,7 +8,7 @@ def test_get(mount_setup):
     mount_setup_path = "test-mount/data/test"
     key = "test_mount"
     filter_ = f".{key}"
-    expected = "test_mount_password"
+    expected = r"test_mount_password\\$"
     vault = Vault()
     result = vault.get(key=key, path=mount_setup_path, filter=filter_)
     assert result == expected


### PR DESCRIPTION
- Returning Raw string instead of parsing. This fixes the case where secret has \\$ in - Python would return \$ - therefore we are calling repr 
